### PR TITLE
[SC-58] 이메일인증 모듈 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// Email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	// Thymeleaf(for email service)
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	// DB

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// Email
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	// DB

--- a/build.gradle
+++ b/build.gradle
@@ -25,21 +25,22 @@ repositories {
 
 dependencies {
 
+
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
-
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
 	// AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'software.amazon.awssdk:s3:2.20.26'
-
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/inu/codin/codin/common/config/MailConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/MailConfig.java
@@ -1,0 +1,60 @@
+package inu.codin.codin.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailConfig {
+
+    private static final String MAIL_SMTP_AUTH = "mail.smtp.auth";
+    private static final String MAIL_DEBUG = "mail.smtp.debug";
+    private static final String MAIL_CONNECTION_TIMEOUT = "mail.smtp.connectiontimeout";
+    private static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
+
+    // SMTP 서버
+    @Value("${spring.mail.host}")
+    private String host;
+    // 계정
+    @Value("${spring.mail.username}")
+    private String username;
+    // 비밀번호
+    @Value("${spring.mail.password}")
+    private String password;
+    // 포트번호
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+    @Value("${spring.mail.properties.mail.smtp.debug}")
+    private boolean debug;
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+    @Value("${spring.mail.properties.mail.starttls.enable}")
+    private boolean startTlsEnable;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties properties = mailSender.getJavaMailProperties();
+        properties.put(MAIL_SMTP_AUTH, auth);
+        properties.put(MAIL_DEBUG, debug);
+        properties.put(MAIL_CONNECTION_TIMEOUT, connectionTimeout);
+        properties.put(MAIL_SMTP_STARTTLS_ENABLE, startTlsEnable);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/inu/codin/codin/common/exception/EmailAuthExistException.java
+++ b/src/main/java/inu/codin/codin/common/exception/EmailAuthExistException.java
@@ -1,0 +1,19 @@
+package inu.codin.codin.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class EmailAuthExistException extends RuntimeException {
+
+    private final String email;
+
+    public EmailAuthExistException(String email) {
+        super("이미 인증된 이메일입니다.");
+        this.email = email;
+    }
+
+    public EmailAuthExistException(String message, String email) {
+        super(message);
+        this.email = email;
+    }
+}

--- a/src/main/java/inu/codin/codin/common/exception/EmailAuthFailException.java
+++ b/src/main/java/inu/codin/codin/common/exception/EmailAuthFailException.java
@@ -3,16 +3,16 @@ package inu.codin.codin.common.exception;
 import lombok.Getter;
 
 @Getter
-public class EmailAuthExistException extends RuntimeException {
+public class EmailAuthFailException extends RuntimeException {
 
     private final String email;
 
-    public EmailAuthExistException(String email) {
+    public EmailAuthFailException(String email) {
         super("이미 인증된 이메일입니다.");
         this.email = email;
     }
 
-    public EmailAuthExistException(String message, String email) {
+    public EmailAuthFailException(String message, String email) {
         super(message);
         this.email = email;
     }

--- a/src/main/java/inu/codin/codin/domain/email/controller/EmailController.java
+++ b/src/main/java/inu/codin/codin/domain/email/controller/EmailController.java
@@ -1,0 +1,43 @@
+package inu.codin.codin.domain.email.controller;
+
+import inu.codin.codin.domain.email.dto.JoinEmailCheckRequestDto;
+import inu.codin.codin.domain.email.dto.JoinEmailSendRequestDto;
+import inu.codin.codin.domain.email.service.EmailAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/email")
+@Tag(name = "Email API")
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final EmailAuthService emailAuthService;
+
+    @Operation(summary = "이메일 인증 코드 전송 - 학교인증 X")
+    @PostMapping("/auth/send")
+    public ResponseEntity<?> sendJoinAuthEmail(
+            @RequestBody @Validated JoinEmailSendRequestDto emailAuthRequestDto
+    ) {
+        emailAuthService.sendAuthEmail(emailAuthRequestDto);
+        return ResponseEntity.ok("Good : " + emailAuthRequestDto.getEmail());
+    }
+
+    @Operation(summary = "이메일 인증 코드 확인 - 학교인증 X")
+    @PostMapping("/auth/check")
+    public ResponseEntity<?> checkAuthNum(
+            @Valid @RequestBody JoinEmailCheckRequestDto joinEmailCheckRequestDto
+    ) {
+        emailAuthService.checkAuthNum(joinEmailCheckRequestDto);
+        return ResponseEntity.ok("Good : " + joinEmailCheckRequestDto.getEmail() + " " + joinEmailCheckRequestDto.getAuthNum());
+    }
+
+}

--- a/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailCheckRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailCheckRequestDto.java
@@ -1,0 +1,22 @@
+package inu.codin.codin.domain.email.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * 이메일 인증 코드 확인 요청 DTO
+ * 해당 이메일로 전송된 인증 코드를 확인한다.
+ */
+@Data
+public class JoinEmailCheckRequestDto {
+
+    @Schema(description = "이메일 주소", example = "example@inu.ac.kr")
+    @Email @NotBlank
+    private String email;
+
+    @Schema(description = "인증 코드 (6자리)", example = "123456")
+    @NotBlank
+    private String authNum;
+}

--- a/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailSendRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailSendRequestDto.java
@@ -1,0 +1,20 @@
+package inu.codin.codin.domain.email.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * 이메일 인증 코드 전송 요청 DTO
+ * 해당 이메일로 인증 코드를 전송한다.
+ */
+@Data
+public class JoinEmailSendRequestDto {
+
+    @Schema(description = "이메일 주소", example = "example@inu.ac.kr")
+    @Email @NotNull @NotEmpty
+    private String email;
+
+}

--- a/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
+++ b/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
@@ -1,0 +1,41 @@
+package inu.codin.codin.domain.email.entity;
+
+import inu.codin.codin.common.BaseTimeEntity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "auth-emails")
+@Getter
+public class EmailAuthEntity extends BaseTimeEntity {
+
+    @Id @NotBlank
+    private String id;
+
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String authNum;
+
+    private boolean isVerified = false;
+
+    private String userId = null;
+
+    @Builder
+    public EmailAuthEntity(String email, String authNum, boolean isVerified, String userId) {
+        this.email = email;
+        this.authNum = authNum;
+    }
+
+    public void verifyEmail() {
+        this.isVerified = true;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+}

--- a/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
+++ b/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
@@ -28,6 +28,10 @@ public class EmailAuthEntity extends BaseTimeEntity {
         this.authNum = authNum;
     }
 
+    public void changeAuthNum(String authNum) {
+        this.authNum = authNum;
+    }
+
     public void verifyEmail() {
         this.isVerified = true;
     }

--- a/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
+++ b/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
@@ -22,8 +22,6 @@ public class EmailAuthEntity extends BaseTimeEntity {
 
     private boolean isVerified = false;
 
-    private String userId = null;
-
     @Builder
     public EmailAuthEntity(String email, String authNum, boolean isVerified, String userId) {
         this.email = email;
@@ -32,10 +30,6 @@ public class EmailAuthEntity extends BaseTimeEntity {
 
     public void verifyEmail() {
         this.isVerified = true;
-    }
-
-    public void setUserId(String userId) {
-        this.userId = userId;
     }
 
 }

--- a/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
+++ b/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
@@ -23,7 +23,7 @@ public class EmailAuthEntity extends BaseTimeEntity {
     private boolean isVerified = false;
 
     @Builder
-    public EmailAuthEntity(String email, String authNum, boolean isVerified, String userId) {
+    public EmailAuthEntity(String email, String authNum) {
         this.email = email;
         this.authNum = authNum;
     }

--- a/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
+++ b/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDateTime;
+
 @Document(collection = "auth-emails")
 @Getter
 public class EmailAuthEntity extends BaseTimeEntity {
@@ -36,4 +38,10 @@ public class EmailAuthEntity extends BaseTimeEntity {
         this.isVerified = true;
     }
 
+    /**
+     * 10분 이상이면 만료됌
+     */
+    public boolean isExpired() {
+        return getCreatedAt().plusMinutes(10).isBefore(LocalDateTime.now());
+    }
 }

--- a/src/main/java/inu/codin/codin/domain/email/repository/EmailAuthRepository.java
+++ b/src/main/java/inu/codin/codin/domain/email/repository/EmailAuthRepository.java
@@ -1,0 +1,15 @@
+package inu.codin.codin.domain.email.repository;
+
+import inu.codin.codin.domain.email.entity.EmailAuthEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailAuthRepository extends MongoRepository<EmailAuthEntity, String> {
+
+    Boolean existsByEmail(String email);
+
+    Optional<EmailAuthEntity> findByEmailAndAuthNum(String email, String authNum);
+}

--- a/src/main/java/inu/codin/codin/domain/email/repository/EmailAuthRepository.java
+++ b/src/main/java/inu/codin/codin/domain/email/repository/EmailAuthRepository.java
@@ -9,7 +9,8 @@ import java.util.Optional;
 @Repository
 public interface EmailAuthRepository extends MongoRepository<EmailAuthEntity, String> {
 
-    Boolean existsByEmail(String email);
+    Optional<EmailAuthEntity> findByEmail(String email);
 
     Optional<EmailAuthEntity> findByEmailAndAuthNum(String email, String authNum);
+
 }

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
@@ -1,0 +1,58 @@
+package inu.codin.codin.domain.email.service;
+
+import inu.codin.codin.common.exception.EmailAuthExistException;
+import inu.codin.codin.domain.email.dto.JoinEmailCheckRequestDto;
+import inu.codin.codin.domain.email.dto.JoinEmailSendRequestDto;
+import inu.codin.codin.domain.email.entity.EmailAuthEntity;
+import inu.codin.codin.domain.email.repository.EmailAuthRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailAuthService {
+
+    private final EmailAuthRepository emailAuthRepository;
+
+    // + 비동기 방식 고려
+    public void sendAuthEmail(JoinEmailSendRequestDto joinEmailSendRequestDto) {
+
+        String email = joinEmailSendRequestDto.getEmail();
+        log.info("[sendAuthEmail] email : {}", email);
+
+        if (emailAuthRepository.existsByEmail(email))
+            throw new EmailAuthExistException(email);
+
+        EmailAuthEntity emailAuthEntity = EmailAuthEntity.builder()
+                .email(email)
+                .authNum(generateAuthNum())
+                .build();
+
+        emailAuthRepository.save(emailAuthEntity);
+
+        // + 이메일 전송 로직 추가
+    }
+
+    private String generateAuthNum() {
+        // 8자리 인증번호 생성
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+
+    public void checkAuthNum(JoinEmailCheckRequestDto joinEmailCheckRequestDto) {
+
+        String email = joinEmailCheckRequestDto.getEmail();
+        String authNum = joinEmailCheckRequestDto.getAuthNum();
+        log.info("[checkAuthNum] email : {}, authNum : {}", email, authNum);
+
+        // 이메일과 인증번호가 일치하는지 확인
+        EmailAuthEntity emailAuthEntity = emailAuthRepository.findByEmailAndAuthNum(email, authNum)
+                .orElseThrow(() -> new IllegalArgumentException("인증번호가 일치하지 않습니다."));
+
+        log.info("[checkAuthNum] Email Auth SUCCESS!!, email : {}", email);
+        emailAuthEntity.verifyEmail();
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
@@ -67,6 +67,11 @@ public class EmailAuthService {
         EmailAuthEntity emailAuthEntity = emailAuthRepository.findByEmailAndAuthNum(email, authNum)
                 .orElseThrow(() -> new IllegalArgumentException("인증번호가 일치하지 않습니다."));
 
+        // 10분 이내에 인증하지 않을 시에 인증번호 만료
+        if (emailAuthEntity.isExpired()) {
+            throw new EmailAuthFailException("인증번호가 만료되었습니다.", email);
+        }
+
         log.info("[checkAuthNum] Email Auth SUCCESS!!, email : {}", email);
         emailAuthEntity.verifyEmail();
     }

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 public class EmailAuthService {
 
     private final EmailAuthRepository emailAuthRepository;
+    private final EmailSendService emailSendService;
 
     // + 비동기 방식 고려
     public void sendAuthEmail(JoinEmailSendRequestDto joinEmailSendRequestDto) {
@@ -35,6 +36,7 @@ public class EmailAuthService {
         emailAuthRepository.save(emailAuthEntity);
 
         // + 이메일 전송 로직 추가
+        emailSendService.sendAuthEmail(email, emailAuthEntity.getAuthNum());
     }
 
     private String generateAuthNum() {

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailSendService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailSendService.java
@@ -9,6 +9,7 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @Service
@@ -27,9 +28,17 @@ public class EmailSendService {
         MimeMessage message = javaMailSender.createMimeMessage();
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+
+            Context context = new Context();
+            context.setVariable("authNum", authNum);
+
+            // 템플릿 엔진을 사용하여 HTML 내용을 생성
+            String htmlContent = templateEngine.process("auth-email", context);
+
             helper.setTo(email);
             helper.setSubject("[CODIN] 회원가입 인증번호입니다.");
-            helper.setText("인증번호 : " + authNum, true);
+            helper.setText(htmlContent, true);
+
             javaMailSender.send(message);
             log.info("[sendAuthEmail] 인증 이메일 전송 성공, email : {}", email);
         } catch (MessagingException e) {

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailSendService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailSendService.java
@@ -1,0 +1,40 @@
+package inu.codin.codin.domain.email.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class EmailSendService {
+
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    // 이메일 전송 로직
+    // +템플릿 엔진으로 이메일 전송 추가 필요!!
+    @Async
+    public void sendAuthEmail(String email, String authNum) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+            helper.setTo(email);
+            helper.setSubject("[CODIN] 회원가입 인증번호입니다.");
+            helper.setText("인증번호 : " + authNum, true);
+            javaMailSender.send(message);
+            log.info("[sendAuthEmail] 인증 이메일 전송 성공, email : {}", email);
+        } catch (MessagingException e) {
+            log.error("[sendAuthEmail] 인증 이메일 전송 실패, email : {}", email);
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

이메일 인증 서비스 구축

![swagger예시](https://github.com/user-attachments/assets/25ddfca4-e525-42f9-87d8-015b29887898)
![이메일예시](https://github.com/user-attachments/assets/df81a8e6-508e-4b88-91c4-2f06b4fef708)

- Gradle 추가된 라이브러리
  - Spring Security
  - Spring Validation
  - Spring Email
  - Thymeleaf (이메일 템플릿 엔진)

## 💬 리뷰 요구사항

- 다른 로컬에서 잘 작동되는지 확인해주세요.
- resources 디렉토리 내에서 아래와 같은 내용 추가 필요합니다. **Notion resources Page에 첨부**
  - template/auth-email.html 파일 추가
  - application-email.yml 파일 추가