### PR TITLE
[SC-56] 회원가입기능추가

### DIFF
--- a/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -43,4 +45,8 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/src/main/java/inu/codin/codin/domain/email/controller/EmailController.java
+++ b/src/main/java/inu/codin/codin/domain/email/controller/EmailController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,19 +24,19 @@ public class EmailController {
     @Operation(summary = "이메일 인증 코드 전송 - 학교인증 X")
     @PostMapping("/auth/send")
     public ResponseEntity<?> sendJoinAuthEmail(
-            @RequestBody @Validated JoinEmailSendRequestDto emailAuthRequestDto
+            @RequestBody @Valid JoinEmailSendRequestDto emailAuthRequestDto
     ) {
         emailAuthService.sendAuthEmail(emailAuthRequestDto);
-        return ResponseEntity.ok("Good : " + emailAuthRequestDto.getEmail());
+        return ResponseEntity.ok("이메일 인증 코드 전송 성공");
     }
 
     @Operation(summary = "이메일 인증 코드 확인 - 학교인증 X")
     @PostMapping("/auth/check")
     public ResponseEntity<?> checkAuthNum(
-            @Valid @RequestBody JoinEmailCheckRequestDto joinEmailCheckRequestDto
+            @RequestBody @Valid JoinEmailCheckRequestDto joinEmailCheckRequestDto
     ) {
         emailAuthService.checkAuthNum(joinEmailCheckRequestDto);
-        return ResponseEntity.ok("Good : " + joinEmailCheckRequestDto.getEmail() + " " + joinEmailCheckRequestDto.getAuthNum());
+        return ResponseEntity.ok("이메일 인증성공 - 회원가입 가능");
     }
 
 }

--- a/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailSendRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailSendRequestDto.java
@@ -2,8 +2,7 @@ package inu.codin.codin.domain.email.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 /**
@@ -14,7 +13,7 @@ import lombok.Data;
 public class JoinEmailSendRequestDto {
 
     @Schema(description = "이메일 주소", example = "example@inu.ac.kr")
-    @Email @NotNull @NotEmpty
+    @Email @NotBlank
     private String email;
 
 }

--- a/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
+++ b/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
@@ -42,6 +42,6 @@ public class EmailAuthEntity extends BaseTimeEntity {
      * 10분 이상이면 만료됌
      */
     public boolean isExpired() {
-        return getCreatedAt().plusMinutes(10).isBefore(LocalDateTime.now());
+        return getUpdatedAt().plusMinutes(10).isBefore(LocalDateTime.now());
     }
 }

--- a/src/main/java/inu/codin/codin/domain/email/exception/EmailAuthFailException.java
+++ b/src/main/java/inu/codin/codin/domain/email/exception/EmailAuthFailException.java
@@ -1,4 +1,4 @@
-package inu.codin.codin.common.exception;
+package inu.codin.codin.domain.email.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
@@ -65,7 +65,7 @@ public class EmailAuthService {
 
         // 이메일과 인증번호가 일치하는지 확인
         EmailAuthEntity emailAuthEntity = emailAuthRepository.findByEmailAndAuthNum(email, authNum)
-                .orElseThrow(() -> new IllegalArgumentException("인증번호가 일치하지 않습니다."));
+                .orElseThrow(() -> new EmailAuthFailException("인증번호가 일치하지 않습니다.", email));
 
         // 10분 이내에 인증하지 않을 시에 인증번호 만료
         if (emailAuthEntity.isExpired()) {

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
@@ -20,7 +20,6 @@ public class EmailAuthService {
     private final EmailAuthRepository emailAuthRepository;
     private final EmailSendService emailSendService;
 
-    // + 비동기 방식 고려
     public void sendAuthEmail(JoinEmailSendRequestDto joinEmailSendRequestDto) {
 
         String email = joinEmailSendRequestDto.getEmail();
@@ -33,6 +32,7 @@ public class EmailAuthService {
         if (emailAuth.isPresent()) {
             emailAuthEntity = emailAuth.get();
 
+            // 이미 인증된 이메일 체크
             if (emailAuthEntity.isVerified()) {
                 throw new EmailAuthFailException("이미 인증된 이메일입니다.", email);
             }
@@ -48,7 +48,7 @@ public class EmailAuthService {
         }
         emailAuthRepository.save(emailAuthEntity);
 
-        // 이메일 전송 로직
+        // 비동기 이메일 전송 로직
         emailSendService.sendAuthEmail(email, emailAuthEntity.getAuthNum());
     }
 

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
@@ -1,6 +1,6 @@
 package inu.codin.codin.domain.email.service;
 
-import inu.codin.codin.common.exception.EmailAuthFailException;
+import inu.codin.codin.domain.email.exception.EmailAuthFailException;
 import inu.codin.codin.domain.email.dto.JoinEmailCheckRequestDto;
 import inu.codin.codin.domain.email.dto.JoinEmailSendRequestDto;
 import inu.codin.codin.domain.email.entity.EmailAuthEntity;
@@ -72,7 +72,8 @@ public class EmailAuthService {
             throw new EmailAuthFailException("인증번호가 만료되었습니다.", email);
         }
 
-        log.info("[checkAuthNum] Email Auth SUCCESS!!, email : {}", email);
         emailAuthEntity.verifyEmail();
+        emailAuthRepository.save(emailAuthEntity);
+        log.info("[checkAuthNum] Email AUTH SUCCESS!!, email : {}", email);
     }
 }

--- a/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
+++ b/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package inu.codin.codin.domain.user.controller;
+
+import inu.codin.codin.domain.user.dto.UserCreateRequestDto;
+import inu.codin.codin.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@Tag(name = "User API")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원가입")
+    @PostMapping("/signup")
+    public ResponseEntity<?> signUpUser(
+            @RequestBody @Valid UserCreateRequestDto userCreateRequestDto) {
+        userService.signUpUser(userCreateRequestDto);
+        return ResponseEntity.ok("회원가입 성공");
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/user/dto/UserCreateRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/user/dto/UserCreateRequestDto.java
@@ -1,0 +1,43 @@
+package inu.codin.codin.domain.user.dto;
+
+import inu.codin.codin.domain.user.entity.Department;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class UserCreateRequestDto {
+
+    // todo : 길이 관련 validation 추가
+
+    @Schema(description = "이메일 주소", example = "codin@inu.ac.kr")
+    @NotBlank
+    private String email;
+
+    @Schema(description = "비밀번호", example = "password")
+    @NotBlank
+    private String password;
+
+    @Schema(description = "학번", example = "20210000")
+    @NotBlank
+    private String studentId;
+
+    @Schema(description = "이름", example = "홍길동")
+    @NotBlank
+    private String name;
+
+    @Schema(description = "닉네임", example = "코딩")
+    @NotBlank
+    private String nickname;
+
+    //todo 프로필 이미지 업로드 처리 ex) 이미지 크기 제한..
+    @Schema(description = "프로필 이미지 URL", example = "https://avatars.githubusercontent.com/u/77490521?v=4")
+    @NotBlank
+    private String profileImageUrl;
+
+    @Schema(description = "소속", example = "IT_COLLEGE")
+    private Department department;
+
+}

--- a/src/main/java/inu/codin/codin/domain/user/entity/Department.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/Department.java
@@ -1,0 +1,18 @@
+package inu.codin.codin.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Department {
+
+    IT_COLLEGE("정보기술대학"),
+    COMPUTER_SCI("컴퓨터공학과"),
+    INFO_COMM("정보통신공학과"),
+    EMBEDDED("임베디드시스템공학과"),
+    STAFF("교직원");
+
+    private final String description;
+
+}

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -1,0 +1,47 @@
+package inu.codin.codin.domain.user.entity;
+
+import inu.codin.codin.common.BaseTimeEntity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "users")
+@Getter
+public class UserEntity extends BaseTimeEntity {
+
+    @Id @NotBlank
+    private String id;
+
+    private String email;
+
+    private String password;
+
+    private String studentId;
+
+    private String name;
+
+    private String nickname;
+
+    private String profileImageUrl;
+
+    private Department department;
+
+    private UserRole role;
+
+    private UserStatus status;
+
+    @Builder
+    public UserEntity(String email, String password, String studentId, String name, String nickname, String profileImageUrl, Department department, UserRole role, UserStatus status) {
+        this.email = email;
+        this.password = password;
+        this.studentId = studentId;
+        this.name = name;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.department = department;
+        this.role = role;
+        this.status = status;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserRole.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserRole.java
@@ -1,0 +1,16 @@
+package inu.codin.codin.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    ADMIN("관리자"),
+    MANAGER("교직원"),
+    USER("사용자");
+
+    private final String description;
+
+}

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserStatus.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserStatus.java
@@ -1,0 +1,16 @@
+package inu.codin.codin.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserStatus {
+
+    ACTIVE("활성"),
+    DISABLED("비활성"),
+    SUSPENDED("정지");
+
+    private final String description;
+
+}

--- a/src/main/java/inu/codin/codin/domain/user/exception/UserCreateFailException.java
+++ b/src/main/java/inu/codin/codin/domain/user/exception/UserCreateFailException.java
@@ -1,0 +1,7 @@
+package inu.codin.codin.domain.user.exception;
+
+public class UserCreateFailException extends RuntimeException {
+    public UserCreateFailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/user/repository/UserRepository.java
+++ b/src/main/java/inu/codin/codin/domain/user/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package inu.codin.codin.domain.user.repository;
+
+import inu.codin.codin.domain.user.entity.UserEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends MongoRepository<UserEntity, String> {
+
+    Optional<Object> findByEmail(String email);
+
+    Optional<Object> findByStudentId(String studentId);
+
+}

--- a/src/main/java/inu/codin/codin/domain/user/service/UserService.java
+++ b/src/main/java/inu/codin/codin/domain/user/service/UserService.java
@@ -1,0 +1,61 @@
+package inu.codin.codin.domain.user.service;
+
+import inu.codin.codin.domain.email.entity.EmailAuthEntity;
+import inu.codin.codin.domain.email.repository.EmailAuthRepository;
+import inu.codin.codin.domain.user.dto.UserCreateRequestDto;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.domain.user.entity.UserRole;
+import inu.codin.codin.domain.user.entity.UserStatus;
+import inu.codin.codin.domain.user.exception.UserCreateFailException;
+import inu.codin.codin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final EmailAuthRepository emailAuthRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signUpUser(UserCreateRequestDto userCreateRequestDto) {
+
+        String encodedPassword = passwordEncoder.encode(userCreateRequestDto.getPassword());
+
+        validateUserCreateRequest(userCreateRequestDto);
+        log.info("[signUpUser] UserCreateRequestDto : {}", userCreateRequestDto);
+
+        // todo : 중복 이메일, 닉네임 체크, 유저 상태, 유저 역할 변경 기능 추가
+        UserEntity user = UserEntity.builder()
+                .email(userCreateRequestDto.getEmail())
+                .password(encodedPassword)
+                .studentId(userCreateRequestDto.getStudentId())
+                .name(userCreateRequestDto.getName())
+                .nickname(userCreateRequestDto.getNickname())
+                .profileImageUrl(userCreateRequestDto.getProfileImageUrl())
+                .department(userCreateRequestDto.getDepartment())
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+
+        userRepository.save(user);
+        log.info("[signUpUser] SIGN UP SUCCESS!! : {}", user.getEmail());
+    }
+
+    // todo : 정책적으로 보안 위반 사항 확인 -> 에러 메세지를 통해서 유추 금지
+    private void validateUserCreateRequest(UserCreateRequestDto userCreateRequestDto) {
+        EmailAuthEntity emailAuth = emailAuthRepository.findByEmail(userCreateRequestDto.getEmail()).orElseThrow(() ->
+                new UserCreateFailException("이메일 인증을 먼저 진행해주세요."));
+        if (!emailAuth.isVerified())
+            throw new UserCreateFailException("이메일 인증을 먼저 진행해주세요.");
+        if (userRepository.findByEmail(userCreateRequestDto.getEmail()).isPresent())
+            throw new UserCreateFailException("이미 존재하는 이메일입니다.");
+        if (userRepository.findByStudentId(userCreateRequestDto.getStudentId()).isPresent())
+            throw new UserCreateFailException("이미 존재하는 학번입니다.");
+    }
+
+}


### PR DESCRIPTION
## 📝 작업 내용

![스크린샷1](https://github.com/user-attachments/assets/3c7979a7-9a24-4339-81cc-4237aaf026d0)

- 회원가입 API 생성
  - User Entity 생성
    - 3개의 Enum 클래스 생성 : Department, UserRole, UserStatus 
  - Email 인증을 완료한 이메일로만 계정 생성 가능토록함
  - 기존 Email 도메인에서 버그 수정 및 리펙토링 진행

## 💬 리뷰 요구사항

- 테스트 추가 해야함
- 유저 생성 정책 추가 필요
  - ex) UserSatus, UserRole 기본값 및 DTO Valid 값 : 최대 글자 수 등등..
 
> 이메일 인증 후 테스트 봐주고, 코드 상 고칠 부분 있음 말해주세요.
