### PR TITLE
[SC-57] 로그인기능추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,10 @@ repositories {
 
 dependencies {
 
-
+	// JWT Token
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// Email

--- a/src/main/java/inu/codin/codin/CodinApplication.java
+++ b/src/main/java/inu/codin/codin/CodinApplication.java
@@ -4,12 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableMongoAuditing
 public class CodinApplication {
-
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(CodinApplication.class, args);
 	}
-
 }

--- a/src/main/java/inu/codin/codin/TestController.java
+++ b/src/main/java/inu/codin/codin/TestController.java
@@ -1,5 +1,7 @@
 package inu.codin.codin;
 
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,9 +10,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v3/api")
 public class TestController {
 
+    @Operation(summary = "기본 접근 테스트")
     @GetMapping("/test")
-    public String test() {
+    public String test1() {
         return "test";
+    }
+
+    @Operation(summary = "기본 접근 테스트 - 로그인 데이터 확인")
+    @GetMapping("/test2")
+    public String test2() {
+        // SecurityContextHolder를 이용하여 현재 사용자의 정보를 가져올 수 있습니다.
+        String username = SecurityContextHolder // SecurityContextHolder를 이용하여 현재 사용자의 정보를 가져올 수 있습니다.
+                .getContext()
+                .getAuthentication()
+                .getName();
+        return "유저 이름: " + username;
     }
 
 }

--- a/src/main/java/inu/codin/codin/TestController.java
+++ b/src/main/java/inu/codin/codin/TestController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/v3/api")
+@RequestMapping(value = "/v3/api", produces = "plain/text; charset=utf-8")
 public class TestController {
 
     @Operation(summary = "기본 접근 테스트")

--- a/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package inu.codin.codin.common.config;
 
+import inu.codin.codin.common.security.filter.JwtAuthenticationFilter;
+import inu.codin.codin.common.security.service.JwtService;
+import inu.codin.codin.common.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,14 +12,20 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+    private final JwtService jwtService;
 
     String[] PERMIT_ALL = {
             "/**",
@@ -40,6 +49,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeHttpRequests) ->
                         authorizeHttpRequests
                                 .requestMatchers(PERMIT_ALL).permitAll()
+                )
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService, jwtService),
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
@@ -2,12 +2,14 @@ package inu.codin.codin.common.config;
 
 import inu.codin.codin.common.security.filter.ExceptionHandlerFilter;
 import inu.codin.codin.common.security.filter.JwtAuthenticationFilter;
+import inu.codin.codin.common.security.jwt.JwtTokenProvider;
 import inu.codin.codin.common.security.jwt.JwtUtils;
 import inu.codin.codin.common.security.service.JwtService;
-import inu.codin.codin.common.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -16,11 +18,13 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -32,20 +36,6 @@ public class SecurityConfig {
     private final JwtService jwtService;
     private final JwtUtils jwtUtils;
 
-    String[] PERMIT_ALL = {
-            "/api/login",
-            "/api/sign-up",
-            "/api/reissue-token",
-            "/api/logout",
-            "/api/members/sign-up",
-            "/api/members/sign-in",
-            "/api/members/refresh-token",
-            "/api/swagger-ui/**",
-            "/api/swagger-ui.html",
-            "/api/v3/api-docs/**",
-            "/**"
-    };
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
@@ -54,10 +44,15 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults()) // cors 설정
                 .formLogin(FormLoginConfigurer::disable) // form login 비활성화
                 .httpBasic(HttpBasicConfigurer::disable) // basic auth 비활성화
+                .sessionManagement(sessionManagement -> sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용하지 않음
+                )
                 // authorizeHttpRequests 메서드를 통해 요청에 대한 권한 설정
                 .authorizeHttpRequests((authorizeHttpRequests) ->
                         authorizeHttpRequests
                                 .requestMatchers(PERMIT_ALL).permitAll()
+                                .requestMatchers(SWAGGER_AUTH_PATHS).permitAll() //.hasRole("ADMIN")
+                                .anyRequest().hasRole("USER")
                 )
                 // JwtAuthenticationFilter 추가
                 .addFilterBefore(
@@ -65,7 +60,7 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class
                 )
                 // 예외 처리 필터 추가
-                .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class);
+                .addFilterBefore(new ExceptionHandlerFilter(), LogoutFilter.class);
 
         return http.build();
     }
@@ -78,7 +73,38 @@ public class SecurityConfig {
     }
 
     @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.fromHierarchy("ROLE_ADMIN > ROLE_MANGER > ROLE_USER");
+    }
+
+    @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    private static final String[] PERMIT_ALL = {
+            // Production Level
+            "/api/auth/login",
+            "/api/auth/reissue",
+            "/api/auth/logout",
+            "/api/users/sign-up",
+            "/api/email/auth/check",
+            "/api/email/auth/send",
+
+            // Local Test Level
+            "/auth/login",
+            "/auth/reissue",
+            "/auth/logout",
+            "/users/sign-up",
+            "/email/auth/check",
+            "/email/auth/send"
+    };
+
+    private static final String[] SWAGGER_AUTH_PATHS = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/v3/api-docs",
+            "/swagger-resources/**",
+    };
+
 }

--- a/src/main/java/inu/codin/codin/common/config/SwaggerConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/SwaggerConfig.java
@@ -43,7 +43,7 @@ public class SwaggerConfig {
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                 .servers(List.of(
                         new Server().url("http://localhost:8080").description("Local Server"),
-                        new Server().url("http://www.codin.co.kr").description("Production Server")
+                        new Server().url("https://www.codin.co.kr").description("Production Server")
                 ));
     }
 

--- a/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
+++ b/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
@@ -1,0 +1,58 @@
+package inu.codin.codin.common.security.controller;
+
+import inu.codin.codin.common.security.dto.LoginRequestDto;
+import inu.codin.codin.common.security.service.JwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/auth" , produces = "plain/text; charset=utf-8")
+@Tag(name = "Auth API")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtService jwtService;
+
+    @Operation(summary = "로그인")
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
+
+        UsernamePasswordAuthenticationToken authenticationToken
+                = new UsernamePasswordAuthenticationToken(loginRequestDto.getEmail(), loginRequestDto.getPassword());
+
+        Authentication authentication = authenticationManager.authenticate(authenticationToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        jwtService.createToken(response);
+
+        return ResponseEntity.ok("로그인 성공 / 토큰 발급 완료");
+    }
+
+    @Operation(summary = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout() {
+        jwtService.deleteToken();
+        return ResponseEntity.ok("로그아웃 성공 / 토큰 삭제 완료");
+    }
+
+    @Operation(summary = "토큰 재발급")
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+        jwtService.reissueToken(request, response);
+        return ResponseEntity.ok("토큰 재발급 완료");
+    }
+
+}

--- a/src/main/java/inu/codin/codin/common/security/dto/LoginRequestDto.java
+++ b/src/main/java/inu/codin/codin/common/security/dto/LoginRequestDto.java
@@ -1,0 +1,18 @@
+package inu.codin.codin.common.security.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginRequestDto {
+
+    @Schema(description = "이메일 주소", example = "codin@gmail.com")
+    @NotBlank
+    private String email;
+
+    @Schema(description = "비밀번호", example = "1234")
+    @NotBlank
+    private String password;
+
+}

--- a/src/main/java/inu/codin/codin/common/security/exception/JwtException.java
+++ b/src/main/java/inu/codin/codin/common/security/exception/JwtException.java
@@ -1,0 +1,19 @@
+package inu.codin.codin.common.security.exception;
+
+import lombok.Getter;
+
+@Getter
+public class JwtException extends RuntimeException {
+
+    private final SecurityErrorCode errorCode;
+
+    public JwtException(SecurityErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public JwtException(SecurityErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/inu/codin/codin/common/security/exception/SecurityErrorCode.java
+++ b/src/main/java/inu/codin/codin/common/security/exception/SecurityErrorCode.java
@@ -1,0 +1,21 @@
+package inu.codin.codin.common.security.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SecurityErrorCode {
+
+    INVALID_TOKEN("SEC_001", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN("SEC_002", "만료된 토큰입니다."),
+    TOKEN_NOT_FOUND("SEC_003", "토큰이 존재하지 않습니다."),
+    INVALID_SIGNATURE("SEC_004", "잘못된 토큰 서명입니다."),
+    ACCESS_DENIED("SEC_005", "접근 권한이 없습니다."),
+    ACCOUNT_LOCKED("SEC_006", "계정이 잠겼습니다. 관리자에게 문의하세요."),
+    INVALID_CREDENTIALS("SEC_007", "잘못된 인증 정보입니다.");
+
+    private final String errorCode;
+    private final String message;
+
+}

--- a/src/main/java/inu/codin/codin/common/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,78 @@
+package inu.codin.codin.common.security.filter;
+
+import inu.codin.codin.common.security.exception.SecurityErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+/**
+ * 예외 처리 필터
+ * - 예외 발생 시, 클라이언트에게 응답을 보내는 필터
+ * - JwtException 발생 시, INVALID_TOKEN 응답
+ * - 그 외 예외 발생 시, INVALID_TOKEN 응답
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            log.error("[doFilterInternal] Exception in ExceptionHandlerFilter: ", e);
+            sendErrorResponse(response, SecurityErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, SecurityErrorCode errorCode) {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .error(errorCode.name())
+                .code(errorCode.getErrorCode())
+                .message(errorCode.getMessage())
+                .build();
+
+        try {
+            response.getWriter().write(errorResponse.toString());
+        } catch (IOException e) {
+            log.error("Error writing error response", e);
+        }
+    }
+
+    @Getter
+    public static class ErrorResponse {
+        private int status;
+        private String error;
+        private String code;
+        private String message;
+        private LocalDateTime timestamp;
+
+        @Builder
+        public ErrorResponse(int status, String error, String code, String message) {
+            this.status = status;
+            this.error = error;
+            this.code = code;
+            this.message = message;
+            this.timestamp = LocalDateTime.now();
+        }
+    }
+
+}

--- a/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
@@ -38,12 +38,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             setAuthentication(accessToken);
         }
         // Refresh Token이 있는 경우 (Access Token 만료) Access Token, Refresh Token 재발급
-//        else if (refreshToken != null) {
-//            if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
-//                setAuthentication(refreshToken);
+        else if (refreshToken != null) {
+            if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
+                setAuthentication(refreshToken);
 //                jwtService.reissueToken(refreshToken, response);
-//            }
-//        }
+            }
+        }
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
@@ -1,18 +1,17 @@
 package inu.codin.codin.common.security.filter;
 
 import inu.codin.codin.common.security.jwt.JwtAuthenticationToken;
-import inu.codin.codin.common.security.service.JwtService;
 import inu.codin.codin.common.security.jwt.JwtTokenProvider;
+import inu.codin.codin.common.security.jwt.JwtUtils;
+import inu.codin.codin.common.security.service.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -26,58 +25,37 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
     private final JwtService jwtService;
+    private final JwtUtils jwtUtils;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String accessToken = getTokenFromHeader(request);
-        String refreshToken = getTokenFromCookie(request);
+        String accessToken = jwtUtils.getTokenFromHeader(request);
+        String refreshToken = jwtUtils.getTokenFromCookie(request);
 
         // Access Token이 있는 경우
-        if (accessToken != null && jwtTokenProvider.validateAccessToken(accessToken)) {
-            String username = jwtTokenProvider.getUsername(accessToken);
-            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        if (accessToken != null) {
+            if (jwtTokenProvider.validateAccessToken(accessToken)) {
+                String username = jwtTokenProvider.getUsername(accessToken);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
-            // 토큰이 유효하고, SecurityContext에 Authentication 객체가 없는 경우
-            if (userDetails != null) {
-                // Authentication 객체 생성 후 SecurityContext에 저장 (인증 완료)
-                JwtAuthenticationToken authentication = new JwtAuthenticationToken(userDetails, userDetails.getAuthorities());
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                // 토큰이 유효하고, SecurityContext에 Authentication 객체가 없는 경우
+                if (userDetails != null) {
+                    // Authentication 객체 생성 후 SecurityContext에 저장 (인증 완료)
+                    JwtAuthenticationToken authentication = new JwtAuthenticationToken(userDetails, userDetails.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
         }
         // Refresh Token이 있는 경우 (Access Token 만료) Access Token, Refresh Token 재발급
-        else if (refreshToken != null && jwtTokenProvider.validateRefreshToken(refreshToken)) {
-            jwtService.reissueToken(refreshToken, response);
+        else if (refreshToken != null) {
+            if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
+                jwtService.reissueToken(refreshToken, response);
+            }
         }
 
         filterChain.doFilter(request, response);
     }
 
-    /**
-     * 헤더에서 Access 토큰 추출
-     * HTTP Header : "Authorization" : "Bearer ..."
-     * @return (null, 빈 문자열, "Bearer ")로 시작하지 않는 경우 null 반환
-     */
-    private String getTokenFromHeader(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
 
-    /**
-     * 쿠키에서 Refresh 토큰 추출
-     * @return 쿠키에 RefreshToken이 없는 경우 null 반환
-     */
-    private String getTokenFromCookie(HttpServletRequest request) {
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
-                if (cookie.getName().equals("RefreshToken")) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
-    }
 }

--- a/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
@@ -34,27 +34,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String refreshToken = jwtUtils.getTokenFromCookie(request);
 
         // Access Token이 있는 경우
-        if (accessToken != null) {
-            if (jwtTokenProvider.validateAccessToken(accessToken)) {
-                String username = jwtTokenProvider.getUsername(accessToken);
-                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-
-                // 토큰이 유효하고, SecurityContext에 Authentication 객체가 없는 경우
-                if (userDetails != null) {
-                    // Authentication 객체 생성 후 SecurityContext에 저장 (인증 완료)
-                    JwtAuthenticationToken authentication = new JwtAuthenticationToken(userDetails, userDetails.getAuthorities());
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                }
-            }
+        if (accessToken != null && jwtTokenProvider.validateAccessToken(accessToken)) {
+            setAuthentication(accessToken);
         }
         // Refresh Token이 있는 경우 (Access Token 만료) Access Token, Refresh Token 재발급
-        else if (refreshToken != null) {
-            if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
-                jwtService.reissueToken(refreshToken, response);
-            }
-        }
+//        else if (refreshToken != null) {
+//            if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
+//                setAuthentication(refreshToken);
+//                jwtService.reissueToken(refreshToken, response);
+//            }
+//        }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void setAuthentication(String token) {
+        String username = jwtTokenProvider.getUsername(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+        // 토큰이 유효하고, SecurityContext에 Authentication 객체가 없는 경우
+        if (userDetails != null) {
+            // Authentication 객체 생성 후 SecurityContext에 저장 (인증 완료)
+            JwtAuthenticationToken authentication = new JwtAuthenticationToken(userDetails, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
     }
 
 

--- a/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,83 @@
+package inu.codin.codin.common.security.filter;
+
+import inu.codin.codin.common.security.jwt.JwtAuthenticationToken;
+import inu.codin.codin.common.security.service.JwtService;
+import inu.codin.codin.common.security.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 토큰을 검증하여 인증하는 필터
+ */
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = getTokenFromHeader(request);
+        String refreshToken = getTokenFromCookie(request);
+
+        // Access Token이 있는 경우
+        if (accessToken != null && jwtTokenProvider.validateAccessToken(accessToken)) {
+            String username = jwtTokenProvider.getUsername(accessToken);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+            // 토큰이 유효하고, SecurityContext에 Authentication 객체가 없는 경우
+            if (userDetails != null) {
+                // Authentication 객체 생성 후 SecurityContext에 저장 (인증 완료)
+                JwtAuthenticationToken authentication = new JwtAuthenticationToken(userDetails, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+        // Refresh Token이 있는 경우 (Access Token 만료) Access Token, Refresh Token 재발급
+        else if (refreshToken != null && jwtTokenProvider.validateRefreshToken(refreshToken)) {
+            jwtService.reissueToken(refreshToken, response);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 헤더에서 Access 토큰 추출
+     * HTTP Header : "Authorization" : "Bearer ..."
+     * @return (null, 빈 문자열, "Bearer ")로 시작하지 않는 경우 null 반환
+     */
+    private String getTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * 쿠키에서 Refresh 토큰 추출
+     * @return 쿠키에 RefreshToken이 없는 경우 null 반환
+     */
+    private String getTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie.getName().equals("RefreshToken")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,28 @@
+package inu.codin.codin.common.security.jwt;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends UsernamePasswordAuthenticationToken {
+
+    public JwtAuthenticationToken(Object principal, Object credentials) {
+        super(principal, credentials);
+    }
+
+    public JwtAuthenticationToken(UserDetails userDetails, Collection<? extends GrantedAuthority> authorities) {
+        super(userDetails, null, authorities);
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return (UserDetails) super.getPrincipal();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+}

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtTokenProvider.java
@@ -57,8 +57,8 @@ public class JwtTokenProvider {
 
         // 토큰 만료시간 설정
         Date now = new Date();
-        Date accessTokenExpiration = new Date(now.getTime() + Long.parseLong(this.ACCESS_TOKEN_EXPIRATION));
-        Date refreshTokenExpiration = new Date(now.getTime() + Long.parseLong(this.REFRESH_TOKEN_EXPIRATION));
+        Date accessTokenExpiration = new Date(now.getTime() + Long.parseLong(this.ACCESS_TOKEN_EXPIRATION) * 1000);
+        Date refreshTokenExpiration = new Date(now.getTime() + Long.parseLong(this.REFRESH_TOKEN_EXPIRATION) * 1000);
 
         // 토큰 생성
         String accessToken = Jwts.builder()
@@ -106,6 +106,7 @@ public class JwtTokenProvider {
         try {
             Jwts.parserBuilder()
                     .setSigningKey(SECRET_KEY)
+                    .setAllowedClockSkewSeconds(60)
                     .build()
                     .parseClaimsJws(accessToken);
             return true;
@@ -128,7 +129,7 @@ public class JwtTokenProvider {
             // Redis에 저장된 Refresh Token과 비교
             String storedRefreshToken = redisStorageService.getStoredRefreshToken(getClaims(refreshToken).getSubject());
             if (!refreshToken.equals(storedRefreshToken)) {
-                log.error("[validateRefreshToken] 저장된 Refresh Token과 요청된 Refresh Token이 일치하지 않음");
+                log.warn("[validateRefreshToken] 저장된 Refresh Token과 요청된 Refresh Token이 일치하지 않음");
                 return false;
             }
             return true;

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,170 @@
+package inu.codin.codin.common.security.jwt;
+
+import inu.codin.codin.common.security.service.RedisStorageService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성 및 유효성 검사
+ * - 토큰 생성
+ * - 토큰 유효성 검사
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtTokenProvider {
+
+    @Value("${spring.jwt.secret}")
+    private String secret;
+    @Value("${spring.jwt.expiration.access}")
+    private String ACCESS_TOKEN_EXPIRATION;
+    @Value("${spring.jwt.expiration.refresh}")
+    private String REFRESH_TOKEN_EXPIRATION;
+
+    /**
+     * bytes[], String 키는 deprecated 되었기 때문에 Key 타입으로 변경
+     */
+    private Key SECRET_KEY;
+    private final RedisStorageService redisStorageService;
+
+    /**
+     * 양방향 대칭키 방식인 HS512로 사용
+     */
+    @PostConstruct
+    protected void init() {
+        SECRET_KEY = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public TokenDto createToken(Authentication authentication) {
+        // 권한을 authorities에 담아서 String으로 변환
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .reduce((auth1, auth2) -> auth1 + "," + auth2)
+                .orElse("");
+
+        // 토큰 만료시간 설정
+        Date now = new Date();
+        Date accessTokenExpiration = new Date(now.getTime() + Long.parseLong(this.ACCESS_TOKEN_EXPIRATION));
+        Date refreshTokenExpiration = new Date(now.getTime() + Long.parseLong(this.REFRESH_TOKEN_EXPIRATION));
+
+        // 토큰 생성
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setIssuedAt(now)
+                .setExpiration(accessTokenExpiration)
+                .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setIssuedAt(now)
+                .setExpiration(refreshTokenExpiration)
+                .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
+                .compact();
+
+        // Redis에 기존에 저장된 RefreshToken 삭제
+        String beforeRefreshToken = redisStorageService.getStoredRefreshToken(authentication.getName());
+        if (beforeRefreshToken != null) {
+            redisStorageService.deleteRefreshToken(authentication.getName());
+        }
+
+        // Redis에 RefreshToken 저장
+        redisStorageService.saveRefreshToken(
+                authentication.getName(),
+                refreshToken,
+                Long.parseLong(this.REFRESH_TOKEN_EXPIRATION)
+        );
+
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    /**
+     * 토큰 유효성 검사 (토큰 변조, 만료)
+     * @param accessToken
+     * @return true: 유효한 토큰, false: 유효하지 않은 토큰
+     */
+    public boolean validateAccessToken(String accessToken) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(SECRET_KEY)
+                    .build()
+                    .parseClaimsJws(accessToken);
+            return true;
+        } catch (ExpiredJwtException e) { // 토큰 만료
+            log.error("[validateAccessToken] 토큰 만료 : {}", e.getMessage());
+            return false;
+        } catch (Exception e) { // 토큰 변조
+            log.error("[validateAccessToken] 유효하지 않은 토큰 : {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Refresh Token 유효성 검사 : Redis에 저장된 Refresh Token과 비교
+     * @param refreshToken
+     * @return true: 유효한 토큰, false: 유효하지 않은 토큰
+     */
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            // Redis에 저장된 Refresh Token과 비교
+            String storedRefreshToken = redisStorageService.getStoredRefreshToken(getClaims(refreshToken).getSubject());
+            if (!refreshToken.equals(storedRefreshToken)) {
+                log.error("[validateRefreshToken] 저장된 Refresh Token과 요청된 Refresh Token이 일치하지 않음");
+                return false;
+            }
+            return true;
+        } catch (ExpiredJwtException e) { // 토큰 만료
+            log.error("[validateRefreshToken] 토큰 만료 : {}", e.getMessage());
+            return false;
+        } catch (Exception e) { // 토큰 변조
+            log.error("[validateRefreshToken] 유효하지 않은 토큰 : {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /** 토큰에서 username 추출 */
+    public String getUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class TokenDto {
+
+        private String accessToken;
+        private String refreshToken;
+
+        @Builder
+        public TokenDto(String accessToken, String refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(SECRET_KEY)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtTokenProvider.java
@@ -128,6 +128,10 @@ public class JwtTokenProvider {
         try {
             // Redis에 저장된 Refresh Token과 비교
             String storedRefreshToken = redisStorageService.getStoredRefreshToken(getClaims(refreshToken).getSubject());
+            if (storedRefreshToken == null) {
+                log.warn("[validateRefreshToken] 저장된 Refresh Token이 없음");
+                return false;
+            }
             if (!refreshToken.equals(storedRefreshToken)) {
                 log.warn("[validateRefreshToken] 저장된 Refresh Token과 요청된 Refresh Token이 일치하지 않음");
                 return false;

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtUtils.java
@@ -1,0 +1,39 @@
+package inu.codin.codin.common.security.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JwtUtils {
+
+    /**
+     * 헤더에서 Access 토큰 추출
+     * HTTP Header : "Authorization" : "Bearer ..."
+     * @return (null, 빈 문자열, "Bearer ")로 시작하지 않는 경우 null 반환
+     */
+    public String getTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * 쿠키에서 Refresh 토큰 추출
+     * @return 쿠키에 RefreshToken이 없는 경우 null 반환
+     */
+    public String getTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie.getName().equals("RefreshToken")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtUtils.java
@@ -28,7 +28,7 @@ public class JwtUtils {
     public String getTokenFromCookie(HttpServletRequest request) {
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
-                if (cookie.getName().equals("RefreshToken")) {
+                if (cookie.getName().equals("RT")) {
                     return cookie.getValue();
                 }
             }

--- a/src/main/java/inu/codin/codin/common/security/service/JwtService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/JwtService.java
@@ -82,7 +82,7 @@ public class JwtService {
         refreshTokenCookie.setPath("/");
         response.addCookie(refreshTokenCookie);
 
-        log.info("[createBothToken] Access Token, Refresh Token 발급 완료 Refresh : {}", newToken.getRefreshToken());
+        log.info("[createBothToken] Access Token, Refresh Token 발급 완료, email = {}, Refresh : {}",authentication.getName(), newToken.getRefreshToken());
     }
 
     /**

--- a/src/main/java/inu/codin/codin/common/security/service/JwtService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/JwtService.java
@@ -3,7 +3,9 @@ package inu.codin.codin.common.security.service;
 import inu.codin.codin.common.security.exception.JwtException;
 import inu.codin.codin.common.security.exception.SecurityErrorCode;
 import inu.codin.codin.common.security.jwt.JwtTokenProvider;
+import inu.codin.codin.common.security.jwt.JwtUtils;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,25 +21,48 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class JwtService {
 
-    private final JwtTokenProvider jwtTokenProvider;
     private final RedisStorageService redisStorageService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtUtils jwtUtils;
 
     /**
      * 최초 로그인 시 Access Token, Refresh Token 발급
      * @param response
      */
-    public void reissueToken(HttpServletResponse response) {
+    public void createToken(HttpServletResponse response) {
         createBothToken(response);
+        log.info("[createToken] Access Token, Refresh Token 발급 완료");
     }
 
     /**
-     * Reissue : Refresh Token을 이용하여 Access Token, Refresh Token 재발급
+     * Refresh Token을 이용하여 Access Token, Refresh Token 재발급
+     * @param request
+     * @param response
+     */
+    public void reissueToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = jwtUtils.getTokenFromCookie(request);
+
+        if (refreshToken == null) {
+            log.error("[reissueToken] Refresh Token이 없습니다.");
+            throw new JwtException(SecurityErrorCode.INVALID_TOKEN, "Refresh Token이 없습니다.");
+        }
+
+        reissueToken(refreshToken, response);
+    }
+
+    /**
+     * Refresh Token을 이용하여 Access Token, Refresh Token 재발급
+     * @param refreshToken
+     * @param response
      */
     public void reissueToken(String refreshToken, HttpServletResponse response) {
         if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+            log.error("[reissueToken] Refresh Token이 유효하지 않습니다. : {}", refreshToken);
             throw new JwtException(SecurityErrorCode.INVALID_TOKEN, "Refresh Token이 유효하지 않습니다.");
         }
+
         createBothToken(response);
+        log.info("[reissueToken] Access Token, Refresh Token 재발급 완료");
     }
 
     /**
@@ -56,14 +81,18 @@ public class JwtService {
         refreshTokenCookie.setHttpOnly(true);
         refreshTokenCookie.setPath("/");
         response.addCookie(refreshTokenCookie);
+
+        log.info("[createBothToken] Access Token, Refresh Token 발급 완료 Refresh : {}", newToken.getRefreshToken());
     }
 
     /**
      * 로그아웃 - Refresh Token 삭제
      */
     public void deleteToken() {
+        // 어차피 JwtAuthenticationFilter 단에서 토큰을 검증하여 인증을 처리하므로
+        // SecurityContext에 Authentication 객체가 없는 경우는 없다.
         var authentication = SecurityContextHolder.getContext().getAuthentication();
         redisStorageService.deleteRefreshToken(authentication.getName());
+        log.info("[deleteToken] Refresh Token 삭제 완료");
     }
-
 }

--- a/src/main/java/inu/codin/codin/common/security/service/JwtService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/JwtService.java
@@ -1,0 +1,69 @@
+package inu.codin.codin.common.security.service;
+
+import inu.codin.codin.common.security.exception.JwtException;
+import inu.codin.codin.common.security.exception.SecurityErrorCode;
+import inu.codin.codin.common.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+/**
+ * JWT 토큰 관련 비즈니스 로직을 처리하는 서비스
+ *
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisStorageService redisStorageService;
+
+    /**
+     * 최초 로그인 시 Access Token, Refresh Token 발급
+     * @param response
+     */
+    public void reissueToken(HttpServletResponse response) {
+        createBothToken(response);
+    }
+
+    /**
+     * Reissue : Refresh Token을 이용하여 Access Token, Refresh Token 재발급
+     */
+    public void reissueToken(String refreshToken, HttpServletResponse response) {
+        if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+            throw new JwtException(SecurityErrorCode.INVALID_TOKEN, "Refresh Token이 유효하지 않습니다.");
+        }
+        createBothToken(response);
+    }
+
+    /**
+     * Access Token, Refresh Token 생성
+     */
+    private void createBothToken(HttpServletResponse response) {
+        // 새로운 Access Token 발급
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        JwtTokenProvider.TokenDto newToken = jwtTokenProvider.createToken(authentication);
+
+        // 응답 헤더에 Access Token 추가
+        response.setHeader("Authorization", "Bearer " + newToken.getAccessToken());
+
+        // 쿠키에 새로운 Refresh Token 추가
+        Cookie refreshTokenCookie = new Cookie("RefreshToken", newToken.getRefreshToken());
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setPath("/");
+        response.addCookie(refreshTokenCookie);
+    }
+
+    /**
+     * 로그아웃 - Refresh Token 삭제
+     */
+    public void deleteToken() {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        redisStorageService.deleteRefreshToken(authentication.getName());
+    }
+
+}

--- a/src/main/java/inu/codin/codin/common/security/service/JwtService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/JwtService.java
@@ -77,7 +77,7 @@ public class JwtService {
         response.setHeader("Authorization", "Bearer " + newToken.getAccessToken());
 
         // 쿠키에 새로운 Refresh Token 추가
-        Cookie refreshTokenCookie = new Cookie("RefreshToken", newToken.getRefreshToken());
+        Cookie refreshTokenCookie = new Cookie("RT", newToken.getRefreshToken());
         refreshTokenCookie.setHttpOnly(true);
         refreshTokenCookie.setPath("/");
         response.addCookie(refreshTokenCookie);

--- a/src/main/java/inu/codin/codin/common/security/service/RedisStorageService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/RedisStorageService.java
@@ -24,7 +24,7 @@ public class RedisStorageService {
      * @param expiration
      */
     public void saveRefreshToken(String username, String refreshToken, long expiration) {
-        log.info("[RedisStorageService] saveRefreshToken : username = {}, refreshToken = {}, expiration = {}", username, refreshToken, expiration);
+        log.debug("[RedisStorageService] saveRefreshToken : username = {}, refreshToken = {}, expiration = {}", username, refreshToken, expiration);
 
         // null check validation
         if (refreshToken != null && refreshToken.contains("\u0000")) {

--- a/src/main/java/inu/codin/codin/common/security/service/RedisStorageService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/RedisStorageService.java
@@ -38,7 +38,7 @@ public class RedisStorageService {
     /**
      * RefreshToken 조회
      * @param username
-     * @return refreshToken
+     * @return refreshToken or null
      */
     public String getStoredRefreshToken(String username) {
         return redisTemplate.opsForValue().get("RT:" + username);

--- a/src/main/java/inu/codin/codin/common/security/service/RedisStorageService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/RedisStorageService.java
@@ -1,0 +1,39 @@
+package inu.codin.codin.common.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisStorageService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * RefreshToken 저장
+     * @param username
+     * @param refreshToken
+     * @param expiration
+     */
+    public void saveRefreshToken(String username, String refreshToken, long expiration) {
+        redisTemplate.opsForValue().set("RT:" + username, refreshToken, expiration);
+    }
+
+    /**
+     * RefreshToken 조회
+     * @param username
+     * @return refreshToken
+     */
+    public String getStoredRefreshToken(String username) {
+        return redisTemplate.opsForValue().get("RT:" + username);
+    }
+
+    /**
+     * RefreshToken 삭제
+     * @param username
+     */
+    public void deleteRefreshToken(String username) {
+        redisTemplate.delete("RT:" + username);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
+++ b/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
     @PostMapping("/signup")
     public ResponseEntity<?> signUpUser(
             @RequestBody @Valid UserCreateRequestDto userCreateRequestDto) {
-        userService.signUpUser(userCreateRequestDto);
+        userService.createUser(userCreateRequestDto);
         return ResponseEntity.ok("회원가입 성공");
     }
 }

--- a/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
+++ b/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping(value = "/api/users", produces = "plain/text; charset=utf-8")
 @Tag(name = "User API")
 @RequiredArgsConstructor
 public class UserController {

--- a/src/main/java/inu/codin/codin/domain/user/exception/UserDisabledException.java
+++ b/src/main/java/inu/codin/codin/domain/user/exception/UserDisabledException.java
@@ -1,0 +1,13 @@
+package inu.codin.codin.domain.user.exception;
+
+import org.springframework.security.authentication.AccountStatusException;
+
+public class UserDisabledException extends AccountStatusException {
+    public UserDisabledException(String message) {
+        super(message);
+    }
+
+    public UserDisabledException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/user/repository/UserRepository.java
+++ b/src/main/java/inu/codin/codin/domain/user/repository/UserRepository.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends MongoRepository<UserEntity, String> {
 
-    Optional<Object> findByEmail(String email);
+    Optional<UserEntity> findByEmail(String email);
 
-    Optional<Object> findByStudentId(String studentId);
+    Optional<UserEntity> findByStudentId(String studentId);
 
 }

--- a/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetails.java
+++ b/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetails.java
@@ -1,0 +1,101 @@
+package inu.codin.codin.domain.user.security;
+
+import inu.codin.codin.domain.user.entity.Department;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.domain.user.entity.UserRole;
+import inu.codin.codin.domain.user.entity.UserStatus;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final String id;
+    private final String email;
+    private final String password;
+    private final String studentId;
+    private final String name;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final Department department;
+    private final UserRole role;
+    private final UserStatus status;
+
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    @Builder
+    public CustomUserDetails(String id, String email, String password, String studentId, String name, String nickname, String profileImageUrl, Department department, UserRole role, UserStatus status, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.studentId = studentId;
+        this.name = name;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.department = department;
+        this.role = role;
+        this.status = status;
+        this.authorities = authorities;
+    }
+
+    public static CustomUserDetails from(UserEntity userEntity) {
+        return CustomUserDetails.builder()
+                .id(userEntity.getId())
+                .email(userEntity.getEmail())
+                .password(userEntity.getPassword())
+                .studentId(userEntity.getStudentId())
+                .name(userEntity.getName())
+                .nickname(userEntity.getNickname())
+                .profileImageUrl(userEntity.getProfileImageUrl())
+                .department(userEntity.getDepartment())
+                .role(userEntity.getRole())
+                .status(userEntity.getStatus())
+                .authorities(Collections.singletonList(
+                                new SimpleGrantedAuthority("ROLE_" + userEntity.getRole().name())))
+                .build();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        // 계정 만료 여부
+        return !status.equals(UserStatus.DISABLED);
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        // 계정 잠금 여부
+        return !status.equals(UserStatus.SUSPENDED);
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        // 계정 활성화 여부
+        return status.equals(UserStatus.ACTIVE);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetails.java
+++ b/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetails.java
@@ -71,6 +71,9 @@ public class CustomUserDetails implements UserDetails {
         return password;
     }
 
+    /**
+     * Spring Security에서 사용하는 유저네임은 email로 사용
+     */
     @Override
     public String getUsername() {
         return email;

--- a/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetailsService.java
+++ b/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package inu.codin.codin.domain.user.security;
+
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.domain.user.entity.UserStatus;
+import inu.codin.codin.domain.user.exception.UserDisabledException;
+import inu.codin.codin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없음, email :" + email));
+
+        if (!UserStatus.ACTIVE.equals(user.getStatus())) {
+            throw new UserDisabledException("유저가 활성화되지 않았습니다");
+        }
+
+        return CustomUserDetails.from(user);
+    }
+
+}

--- a/src/main/java/inu/codin/codin/domain/user/service/UserService.java
+++ b/src/main/java/inu/codin/codin/domain/user/service/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public void signUpUser(UserCreateRequestDto userCreateRequestDto) {
+    public void createUser(UserCreateRequestDto userCreateRequestDto) {
 
         String encodedPassword = passwordEncoder.encode(userCreateRequestDto.getPassword());
 

--- a/src/main/java/inu/codin/codin/infra/redis/RedisConfig.java
+++ b/src/main/java/inu/codin/codin/infra/redis/RedisConfig.java
@@ -5,8 +5,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 // Redis configuration
@@ -19,16 +21,26 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
+
+        RedisStandaloneConfiguration redisStandAloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandAloneConfiguration.setPort(redisProperties.getPort());
+        redisStandAloneConfiguration.setHostName(redisProperties.getHost());
+        redisStandAloneConfiguration.setPassword(redisProperties.getPassword());
+        redisStandAloneConfiguration.setDatabase(0);
+
         // Lettuce는 비동기 방식을 지원하는 Redis 클라이언트
         // 성능상 이점이 있어 기본적으로 사용
-        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+        return new LettuceConnectionFactory(redisStandAloneConfiguration);
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setDefaultSerializer(RedisSerializer.string());
+        redisTemplate.setEnableTransactionSupport(true);
         return redisTemplate;
     }
 }

--- a/src/main/java/inu/codin/codin/infra/redis/RedisProperties.java
+++ b/src/main/java/inu/codin/codin/infra/redis/RedisProperties.java
@@ -13,4 +13,6 @@ public class RedisProperties {
 
     private int port;
 
+    private String password;
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #7 #8 

## 📝 작업 내용

### 기능
- 로그인, 로그아웃, 토큰 리이슈 기능 추가
- JWT Token을 통해서 접근 (Access, Refresh)

### 토큰 요약
- Access -> 일반적인 접근 : 10분 (Bearer Auth)
- Refresh -> Token Roate : 10일 (Cookie에 "RT"라는 이름으로 들어가게됨)

> 1. Login
> 2. Access, Refresh 발급
> 3. Access를 통해서 접근
> 4. (10분 후) Access 만료
> 5. Refresh Token으로 Reissue -> 새로운 Access, Refresh 발급

### 추후 추가필요

- CI/CD 구축 전에 Production 서버에서 Swagger 접근시 ADMIN 계정만 접근 가능하도록 변경해야함.
- 각 사람마다 ADMIN 계정 생성 및 부여 필요.

### 스크린샷

<img width="1459" alt="스크린샷 2024-11-13 오후 9 07 34" src="https://github.com/user-attachments/assets/4202cfad-ab38-41e0-95f7-20c31c1ba1a3">
<img width="1403" alt="스크린샷 2024-11-13 오후 9 08 10" src="https://github.com/user-attachments/assets/03edf293-d138-46b2-95b0-3f1f95bf0d02">
<img width="1442" alt="스크린샷 2024-11-13 오후 9 09 00" src="https://github.com/user-attachments/assets/779e2b68-8510-45ea-ba7d-4e853b13b265">

## 💬 리뷰 요구사항

> 1. 위에 기능 정상 작동하는지 확인해주세요.
> 2. Token 없이 접근하는 경우 어떻게 되는지 리뷰해주세요.
> 3. Validation 처리 잘 확인해주세요.
> 4. 중요한 내용이라 @gisu1102 @X1n9fU 두분다 확인해주세요.