### PR TITLE
[SC-69]  Feat: 좋아요 및 스크랩 기능 구현

### DIFF
--- a/src/main/java/inu/codin/codin/domain/like/LikeController.java
+++ b/src/main/java/inu/codin/codin/domain/like/LikeController.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/posts/{postId}/likes")
+@RequestMapping("/api/likes/{postId}")
 @RequiredArgsConstructor
 public class LikeController {
 

--- a/src/main/java/inu/codin/codin/domain/like/LikeController.java
+++ b/src/main/java/inu/codin/codin/domain/like/LikeController.java
@@ -1,0 +1,41 @@
+package inu.codin.codin.domain.like;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/likes")
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @Operation(
+            summary = "좋아요 추가"
+    )
+    @PostMapping("/{userId}")
+    public ResponseEntity<String> likePost(@PathVariable String postId, @PathVariable String userId) {
+        likeService.addLike(postId, userId);
+        return ResponseEntity.ok("Liked successfully");
+    }
+
+    @Operation(
+            summary = "좋아요 삭제"
+    )
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<String> unlikePost(@PathVariable String postId, @PathVariable String userId) {
+        likeService.removeLike(postId, userId);
+        return ResponseEntity.ok("Unliked successfully");
+    }
+
+    @Operation(
+            summary = "해당 게시물 좋아요 조회"
+    )
+    @GetMapping
+    public ResponseEntity<Long> getLikeCount(@PathVariable String postId) {
+        long likeCount = likeService.getLikeCount(postId);
+        return ResponseEntity.ok(likeCount);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/like/LikeEntity.java
+++ b/src/main/java/inu/codin/codin/domain/like/LikeEntity.java
@@ -1,0 +1,22 @@
+package inu.codin.codin.domain.like;
+
+import inu.codin.codin.common.BaseTimeEntity;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "likes")
+@Getter
+public class LikeEntity extends BaseTimeEntity {
+    @Id
+    private String id;
+    private String postId;
+    private String userId;
+
+    @Builder
+    public LikeEntity(String postId, String userId) {
+        this.postId = postId;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/like/LikeRepository.java
+++ b/src/main/java/inu/codin/codin/domain/like/LikeRepository.java
@@ -1,0 +1,9 @@
+package inu.codin.codin.domain.like;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends MongoRepository<LikeEntity, String> {
+    boolean findByPostIdAndUserId(String postId, String userId);
+}

--- a/src/main/java/inu/codin/codin/domain/like/LikeService.java
+++ b/src/main/java/inu/codin/codin/domain/like/LikeService.java
@@ -1,0 +1,49 @@
+package inu.codin.codin.domain.like;
+
+import inu.codin.codin.domain.post.entity.PostEntity;
+import inu.codin.codin.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final PostRepository postRepository; // MongoDB의 게시글 저장소
+
+    public void addLike(String postId, String userId) {
+        String redisKey = "post:likes:" + postId;
+
+        if (Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(redisKey, userId))) {
+            throw new IllegalStateException("이미 해당 게시물에 좋아요를 눌렀습니다.");
+        }
+
+        // Redis에 좋아요 추가
+        redisTemplate.opsForSet().add(redisKey, userId);
+
+    }
+
+    public void removeLike(String postId, String userId) {
+        String redisKey = "post:likes:" + postId;
+
+        if (!Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(redisKey, userId))) {
+            throw new IllegalStateException("해당 게시물에 좋아요를 누르지 않았습니다.");
+        }
+
+        // Redis에서 좋아요 제거
+        redisTemplate.opsForSet().remove(redisKey, userId);
+
+    }
+
+    public long getLikeCount(String postId) {
+        String redisKey = "post:likes:" + postId;
+        return redisTemplate.opsForSet().size(redisKey);
+    }
+
+    public boolean isPostLikedByUser(String postId, String userId) {
+        String redisKey = "post:likes:" + postId;
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(redisKey, userId));
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/post/controller/PostController.java
+++ b/src/main/java/inu/codin/codin/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import inu.codin.codin.domain.post.dto.request.PostContentUpdateRequestDTO;
 import inu.codin.codin.domain.post.dto.request.PostCreateReqDTO;
 import inu.codin.codin.domain.post.dto.request.PostStatusUpdateRequestDTO;
 import inu.codin.codin.domain.post.dto.response.PostDetailResponseDTO;
+import inu.codin.codin.domain.post.dto.response.PostWithLikeAndScrapResponseDTO;
 import inu.codin.codin.domain.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -90,6 +91,15 @@ public class PostController {
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailResponseDTO> getPost(@PathVariable String postId) {
         PostDetailResponseDTO post = postService.getPost(postId);
+        return ResponseEntity.status(HttpStatus.OK).body(post);
+    }
+
+    @Operation(
+            summary = "해당 게시물 좋아요,스크랩 포함 조회"
+    )
+    @GetMapping("/{postId}/details")
+    public ResponseEntity<PostWithLikeAndScrapResponseDTO> getPostDetail(@PathVariable String postId) {
+        PostWithLikeAndScrapResponseDTO post = postService.getPostWithLikeAndScrap(postId);
         return ResponseEntity.status(HttpStatus.OK).body(post);
     }
 

--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostWithLikeAndScrapResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostWithLikeAndScrapResponseDTO.java
@@ -1,0 +1,59 @@
+package inu.codin.codin.domain.post.dto.response;
+
+import inu.codin.codin.domain.post.entity.PostCategory;
+import inu.codin.codin.domain.post.entity.PostStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PostWithLikeAndScrapResponseDTO {
+    @Schema(description = "유저 ID", example = "111111")
+    @NotBlank
+    private String userId;
+
+    @Schema(description = "게시물 ID", example = "111111")
+    @NotBlank
+    private String postId;
+
+    @Schema(description = "게시물 종류", example = "구해요")
+    @NotBlank
+    private PostCategory postCategory;
+
+    @Schema(description = "게시물 제목", example = "Example")
+    @NotBlank
+    private String title;
+
+    @Schema(description = "게시물 내용", example = "example content")
+    @NotBlank
+    private String content;
+
+    @Schema(description = "게시물 내 이미지 url , blank 가능", example = "example/1231")
+    private List<String> postImageUrl;
+
+    @Schema(description = "게시물 익명 여부 default = 0 (익명)", example = "0")
+    @NotNull
+    private boolean isAnonymous;
+
+    @Schema(description = "댓글 및 대댓글", example = "0")
+    private List<CommentsResponseDTO> comments;
+
+    private int likeCount;
+    private int scrapCount;
+
+    public PostWithLikeAndScrapResponseDTO(String userId, String postId, String content, String title, PostCategory postCategory, PostStatus postStatus, List<String> postImageUrls , boolean isAnonymous, List<CommentsResponseDTO> comments, int likeCount, int scrapCount) {
+        this.userId = userId;
+        this.postId = postId;
+        this.content = content;
+        this.title = title;
+        this.postCategory = postCategory;
+        this.postImageUrl = postImageUrls;
+        this.isAnonymous = isAnonymous;
+        this.comments = comments;
+        this.likeCount = likeCount;
+        this.scrapCount = scrapCount;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/post/entity/PostEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/entity/PostEntity.java
@@ -35,10 +35,12 @@ public class PostEntity extends BaseTimeEntity {
 
     private List<CommentEntity> comments = new ArrayList<>();
 
+    private int likeCount = 0; // 좋아요 카운트
 
+    private int scrapCount = 0; // 스크랩 카운트
 
     @Builder
-    public PostEntity(String postId, String userId, PostCategory postCategory, String title, String content, boolean isAnonymous, List<String> postImageUrls, PostStatus postStatus, List<CommentEntity> comments) {
+    public PostEntity(String postId, String userId, PostCategory postCategory, String title, String content, boolean isAnonymous, List<String> postImageUrls, PostStatus postStatus, List<CommentEntity> comments, Integer likeCount, Integer scrapCount) {
         this.postId = postId;
         this.userId = userId;
         this.postCategory = postCategory;
@@ -47,7 +49,9 @@ public class PostEntity extends BaseTimeEntity {
         this.isAnonymous = isAnonymous;
         this.postImageUrls = postImageUrls;
         this.postStatus = postStatus;
-        this.comments = comments;
+        this.comments = comments != null ? comments : new ArrayList<>();
+        this.likeCount = likeCount != null ? likeCount : 0; // 기본값 설정
+        this.scrapCount = scrapCount != null ? scrapCount : 0; // 기본값 설정
     }
 
     public void updatePostContent(String content, List<String> postImageUrls) {
@@ -103,6 +107,15 @@ public class PostEntity extends BaseTimeEntity {
                 .filter(comment -> comment.getCommentId().equals(parentCommentId))
                 .findFirst()
                 .ifPresent(parentComment -> parentComment.addReply(reply));
+    }
+
+    //좋아요 업데이트
+    public void updateLikeCount(int likeCount) {
+        this.likeCount=likeCount;
+    }
+    //스크랩 업데이트
+    public void updateScrapCount(int scrapCount) {
+        this.scrapCount=likeCount;
     }
 
 

--- a/src/main/java/inu/codin/codin/domain/scrap/ScrapController.java
+++ b/src/main/java/inu/codin/codin/domain/scrap/ScrapController.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/posts/{postId}/scraps")
+@RequestMapping("/api/scraps/{postId}")
 @RequiredArgsConstructor
 public class ScrapController {
 

--- a/src/main/java/inu/codin/codin/domain/scrap/ScrapController.java
+++ b/src/main/java/inu/codin/codin/domain/scrap/ScrapController.java
@@ -1,0 +1,31 @@
+package inu.codin.codin.domain.scrap;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/scraps")
+@RequiredArgsConstructor
+public class ScrapController {
+
+    private final ScrapService scrapService;
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<String> scrapPost(@PathVariable String postId, @PathVariable String userId) {
+        scrapService.addScrap(postId, userId);
+        return ResponseEntity.ok("Scrapped successfully");
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<String> unscrapPost(@PathVariable String postId, @PathVariable String userId) {
+        scrapService.removeScrap(postId, userId);
+        return ResponseEntity.ok("Unscrapped successfully");
+    }
+
+    @GetMapping
+    public ResponseEntity<Long> getScrapCount(@PathVariable String postId) {
+        long scrapCount = scrapService.getScrapCount(postId);
+        return ResponseEntity.ok(scrapCount);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/scrap/ScrapEntity.java
+++ b/src/main/java/inu/codin/codin/domain/scrap/ScrapEntity.java
@@ -1,0 +1,22 @@
+package inu.codin.codin.domain.scrap;
+
+import inu.codin.codin.common.BaseTimeEntity;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "scraps")
+@Getter
+public class ScrapEntity extends BaseTimeEntity {
+    @Id
+    private String id;
+    private String postId;
+    private String userId;
+
+    @Builder
+    public ScrapEntity(String postId, String userId) {
+        this.postId = postId;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/scrap/ScrapRepository.java
+++ b/src/main/java/inu/codin/codin/domain/scrap/ScrapRepository.java
@@ -1,0 +1,9 @@
+package inu.codin.codin.domain.scrap;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScrapRepository extends MongoRepository<ScrapEntity, String> {
+    boolean findByPostIdAndUserId(String postId, String userId);
+}

--- a/src/main/java/inu/codin/codin/domain/scrap/ScrapService.java
+++ b/src/main/java/inu/codin/codin/domain/scrap/ScrapService.java
@@ -1,0 +1,49 @@
+package inu.codin.codin.domain.scrap;
+
+import inu.codin.codin.domain.post.entity.PostEntity;
+import inu.codin.codin.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void addScrap(String userId, String postId) {
+        String redisKey = "user:scraps:" + userId;
+
+        if (Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(redisKey, postId))) {
+            throw new IllegalStateException("이미 해당 게시물을 스크랩 했습니다.");
+        }
+
+        // Redis에 스크랩 추가
+        redisTemplate.opsForSet().add(redisKey, postId);
+
+    }
+
+    public void removeScrap(String userId, String postId) {
+        String redisKey = "user:scraps:" + userId;
+
+        if (!Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(redisKey, postId))) {
+            throw new IllegalStateException("해당 게시물을 스크랩 하지 않았습니다.");
+        }
+
+        // Redis에서 스크랩 제거
+        redisTemplate.opsForSet().remove(redisKey, postId);
+
+    }
+
+    public long getScrapCount(String postId) {
+        return redisTemplate.opsForSet().size("scraps:" + postId);
+    }
+
+    public Set<String> getScrappedPosts(String userId) {
+        String redisKey = "user:scraps:" + userId;
+        return redisTemplate.opsForSet().members(redisKey);
+    }
+}

--- a/src/main/java/inu/codin/codin/infra/redis/SyncScheduler.java
+++ b/src/main/java/inu/codin/codin/infra/redis/SyncScheduler.java
@@ -1,0 +1,91 @@
+package inu.codin.codin.infra.redis;
+
+import inu.codin.codin.domain.like.LikeEntity;
+import inu.codin.codin.domain.like.LikeRepository;
+import inu.codin.codin.domain.like.LikeService;
+import inu.codin.codin.domain.post.entity.PostEntity;
+import inu.codin.codin.domain.post.repository.PostRepository;
+import inu.codin.codin.domain.post.service.PostService;
+import inu.codin.codin.domain.scrap.ScrapEntity;
+import inu.codin.codin.domain.scrap.ScrapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class SyncScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final PostRepository postRepository;
+    private final LikeRepository likeRepository;
+    private final ScrapRepository scrapRepository;
+
+    @Scheduled(fixedRate = 60000) // 매 1분마다 실행
+    public void syncLikesAndScraps() {
+        syncLikes();
+        syncScraps();
+    }
+
+    private void syncLikes() {
+        Set<String> keys = redisTemplate.keys("post:likes:*");
+        if (keys == null || keys.isEmpty()) return;
+
+        for (String key : keys) {
+            String postId = key.replace("post:likes:", "");
+            Set<String> users = redisTemplate.opsForSet().members(key);
+
+            if (users != null && !users.isEmpty()) {
+                // LikeEntity 동기화
+                users.forEach(userId -> {
+                    if (!likeRepository.findByPostIdAndUserId(postId, userId)) {
+                        likeRepository.save(new LikeEntity(postId, userId));
+                    }
+                });
+
+                // PostEntity의 likeCount 업데이트
+                PostEntity post = postRepository.findById(postId)
+                        .orElseThrow(() -> new IllegalArgumentException("게시물을 찾을 수 없습니다."));
+                int newLikeCount = users.size();
+                if (post.getLikeCount() != newLikeCount) { // 기존 카운트와 다를 경우만 업데이트
+                    post.updateLikeCount(newLikeCount);
+                    postRepository.save(post);
+                }
+            }
+        }
+    }
+
+    private void syncScraps() {
+        Set<String> keys = redisTemplate.keys("user:scraps:*");
+        if (keys == null || keys.isEmpty()) return;
+
+        for (String key : keys) {
+            String userId = key.replace("user:scraps:", "");
+            Set<String> posts = redisTemplate.opsForSet().members(key);
+
+            if (posts != null && !posts.isEmpty()) {
+                // ScrapEntity 동기화
+                posts.forEach(postId -> {
+                    if (!scrapRepository.findByPostIdAndUserId(postId, userId)) {
+                        scrapRepository.save(new ScrapEntity(postId, userId));
+                    }
+                });
+
+                // PostEntity의 scrapCount 업데이트
+                posts.forEach(postId -> {
+                    PostEntity post = postRepository.findById(postId)
+                            .orElseThrow(() -> new IllegalArgumentException("게시물을 찾을 수 없습니다."));
+                    int newScrapCount = redisTemplate.opsForSet().size("post:scraps:" + postId).intValue();
+                    if (post.getScrapCount() != newScrapCount) { // 기존 카운트와 다를 경우만 업데이트
+                        post.updateScrapCount(newScrapCount);
+                        postRepository.save(post);
+                    }
+                });
+            }
+        }
+    }
+
+}


### PR DESCRIPTION



## 📝 작업 내용
좋아요 및 스크랩 생성 ,삭제, 조회
Redis-> 데이터 임시저장
DB -> Sync를 통해 주기적으로 저장 ( 간격 설정 필요 )
조회 : 
-Defalut :: Redis Data 반환
-Redis==Null -> DB 조회후 해당값 반환

### 스크린샷 (선택)
<img width="422" alt="스크린샷 2024-11-25 오후 1 13 54" src="https://github.com/user-attachments/assets/179922ef-9e64-4020-97ca-cbb4b8bf34a8">
<img width="371" alt="스크린샷 2024-11-25 오후 1 14 06" src="https://github.com/user-attachments/assets/9d2879f9-4857-4a87-85d4-bad1db725628">

## 💬 리뷰 요구사항(선택)

1. redis -> DB 동기화 간격 정책 필요 ( 테스트 용이성 때문에 1분으로 설정)
2. Post Entity 에 좋아요,스크랩 count 필드 생성 -> 게시물 반환시 한번에 반환하기 위함
3. 좋아요,스크랩 세부 정보는 각 Entity 에 동기화 통해 저장 
4. 조회 과정 : redis Data 기반 좋아요 스크랩 count 수 반환 (DB 수정 x) 

