### PR TITLE
[SC-86] Refresh Token 로직 변경

### DIFF
--- a/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
@@ -90,6 +90,7 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
+    // 토큰 없이 접근 가능한 URL
     private static final String[] PERMIT_ALL = {
             "/auth/login",
             "/auth/reissue",
@@ -100,6 +101,7 @@ public class SecurityConfig {
             "/v3/api/test1",
     };
 
+    // Swagger 접근 가능한 URL
     private static final String[] SWAGGER_AUTH_PATHS = {
             "/swagger-ui/**",
             "/v3/api-docs/**",
@@ -107,20 +109,26 @@ public class SecurityConfig {
             "/swagger-resources/**",
     };
 
+    // User 권한 URL
     private static final String[] USER_AUTH_PATHS = {
             "/v3/api/test2",
             "/v3/api/test3",
     };
 
+    // Admin 권한 URL
     private static final String[] ADMIN_AUTH_PATHS = {
             "/v3/api/test4",
     };
 
+    // Manager 권한 URL
     private static final String[] MANAGER_AUTH_PATHS = {
             "/v3/api/test5",
     };
 
 
+    /**
+     * CORS 설정
+     */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();

--- a/src/main/java/inu/codin/codin/common/config/SwaggerConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/SwaggerConfig.java
@@ -27,6 +27,7 @@ public class SwaggerConfig {
                 .description("CODIN API 명세서")
                 .version("v1.0.0");
 
+        // Bearer Auth 설정
         SecurityScheme securityScheme = new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
@@ -34,6 +35,7 @@ public class SwaggerConfig {
                 .in(SecurityScheme.In.HEADER)
                 .name("Authorization");
 
+        // Bearer Auth를 사용하는 Security Requirement 설정
         SecurityRequirement securityRequirement = new SecurityRequirement()
                 .addList("Bearer Auth");
 
@@ -42,11 +44,12 @@ public class SwaggerConfig {
                 .security(List.of(securityRequirement))
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                 .servers(List.of(
-                        new Server().url("http://localhost:8080").description("Local Server"),
-                        new Server().url("https://www.codin.co.kr/api").description("Production Server")
+                        new Server().url("http://localhost:8080").description("Local Server"), // Local Server
+                        new Server().url("https://www.codin.co.kr/api").description("Production Server") // Production Server
                 ));
     }
 
+    // ForwardedHeaderFilter Bean 등록 Nginx 프록시 서버 사용 시 필요
     @Bean
     public ForwardedHeaderFilter forwardedHeaderFilter() {
         return new ForwardedHeaderFilter();

--- a/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
+++ b/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
@@ -1,6 +1,7 @@
 package inu.codin.codin.common.security.controller;
 
 import inu.codin.codin.common.ResponseUtils;
+import inu.codin.codin.common.response.SingleResponse;
 import inu.codin.codin.common.security.dto.LoginRequestDto;
 import inu.codin.codin.common.security.service.JwtService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,21 +40,21 @@ public class AuthController {
 
         jwtService.createToken(response);
 
-        return ResponseUtils.successMsg("로그인 성공 / 토큰 발급 완료");
+        return ResponseEntity.ok().body(new SingleResponse<>(200, "로그인 성공", null));
     }
 
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public ResponseEntity<?> logout() {
         jwtService.deleteToken();
-        return ResponseUtils.successMsg("로그아웃 성공 / 토큰 삭제 완료");
+        return ResponseEntity.ok().body(new SingleResponse<>(200, "로그아웃 성공", null));
     }
 
     @Operation(summary = "토큰 재발급")
     @PostMapping("/reissue")
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
         jwtService.reissueToken(request, response);
-        return ResponseUtils.successMsg("토큰 재발급 완료");
+        return ResponseEntity.ok().body(new SingleResponse<>(200, "토큰 재발급 성공", null));
     }
 
 }

--- a/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
+++ b/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
@@ -1,6 +1,5 @@
 package inu.codin.codin.common.security.controller;
 
-import inu.codin.codin.common.ResponseUtils;
 import inu.codin.codin.common.response.SingleResponse;
 import inu.codin.codin.common.security.dto.LoginRequestDto;
 import inu.codin.codin.common.security.service.JwtService;

--- a/src/main/java/inu/codin/codin/common/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/ExceptionHandlerFilter.java
@@ -2,6 +2,7 @@ package inu.codin.codin.common.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inu.codin.codin.common.ResponseUtils;
+import inu.codin.codin.common.response.ExceptionResponse;
 import inu.codin.codin.common.security.exception.SecurityErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -9,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -37,7 +39,7 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
     }
 
     private void sendErrorResponse(HttpServletResponse response, SecurityErrorCode code) throws IOException {
-        ResponseEntity<?> responseEntity = ResponseUtils.error("Security Fail", code);
+        ResponseEntity<?> responseEntity = ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ExceptionResponse(code.getMessage(), HttpStatus.UNAUTHORIZED.value()));
 
         // Set the HttpServletResponse properties
         response.setStatus(responseEntity.getStatusCode().value());

--- a/src/main/java/inu/codin/codin/common/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/ExceptionHandlerFilter.java
@@ -1,7 +1,6 @@
 package inu.codin.codin.common.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import inu.codin.codin.common.ResponseUtils;
 import inu.codin.codin.common.response.ExceptionResponse;
 import inu.codin.codin.common.security.exception.SecurityErrorCode;
 import jakarta.servlet.FilterChain;

--- a/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
@@ -3,7 +3,6 @@ package inu.codin.codin.common.security.filter;
 import inu.codin.codin.common.security.jwt.JwtAuthenticationToken;
 import inu.codin.codin.common.security.jwt.JwtTokenProvider;
 import inu.codin.codin.common.security.jwt.JwtUtils;
-import inu.codin.codin.common.security.service.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,7 +23,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
-    private final JwtService jwtService;
     private final JwtUtils jwtUtils;
 
     @Override

--- a/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String accessToken = jwtUtils.getTokenFromHeader(request);
+        String accessToken = jwtUtils.getAccessToken(request);
 
         // Access Token이 있는 경우
         if (accessToken != null && jwtTokenProvider.validateAccessToken(accessToken)) {

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtUtils.java
@@ -1,6 +1,5 @@
 package inu.codin.codin.common.security.jwt;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtUtils.java
@@ -13,7 +13,7 @@ public class JwtUtils {
      * HTTP Header : "Authorization" : "Bearer ..."
      * @return (null, 빈 문자열, "Bearer ")로 시작하지 않는 경우 null 반환
      */
-    public String getTokenFromHeader(HttpServletRequest request) {
+    public String getAccessToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
@@ -22,16 +22,14 @@ public class JwtUtils {
     }
 
     /**
-     * 쿠키에서 Refresh 토큰 추출
-     * @return 쿠키에 RefreshToken이 없는 경우 null 반환
+     * 헤더에서 Refresh 토큰 추출
+     * HTTP Header : "X-Refresh-Token" : "..."
+     * @return RefreshToken이 없는 경우 null 반환
      */
-    public String getTokenFromCookie(HttpServletRequest request) {
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
-                if (cookie.getName().equals("RT")) {
-                    return cookie.getValue();
-                }
-            }
+    public String getRefreshToken(HttpServletRequest request) {
+        String refreshToken = request.getHeader("X-Refresh-Token");
+        if (StringUtils.hasText(refreshToken)) {
+            return refreshToken;
         }
         return null;
     }

--- a/src/main/java/inu/codin/codin/common/security/service/JwtService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/JwtService.java
@@ -5,7 +5,6 @@ import inu.codin.codin.common.security.exception.SecurityErrorCode;
 import inu.codin.codin.common.security.jwt.JwtAuthenticationToken;
 import inu.codin.codin.common.security.jwt.JwtTokenProvider;
 import inu.codin.codin.common.security.jwt.JwtUtils;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +43,7 @@ public class JwtService {
      * @param response
      */
     public void reissueToken(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = jwtUtils.getTokenFromCookie(request);
+        String refreshToken = jwtUtils.getRefreshToken(request);
 
         if (refreshToken == null) {
             log.error("[reissueToken] Refresh Token이 없습니다.");
@@ -90,13 +89,8 @@ public class JwtService {
         // 응답 헤더에 Access Token 추가
         response.setHeader("Authorization", "Bearer " + newToken.getAccessToken());
 
-        // 쿠키에 새로운 Refresh Token 추가
-        Cookie refreshTokenCookie = new Cookie("RT", newToken.getRefreshToken());
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setAttribute("SameSite", "None");  // CORS 설정을 통해 SameSite=None 설정 필요
-        refreshTokenCookie.setSecure(true);
-        refreshTokenCookie.setPath("/");
-        response.addCookie(refreshTokenCookie);
+        // 헤더에 Access Token 추가
+        response.addHeader("X-Refresh-Token", newToken.getRefreshToken());
 
         log.info("[createBothToken] Access Token, Refresh Token 발급 완료, email = {}, Refresh : {}",authentication.getName(), newToken.getRefreshToken());
     }


### PR DESCRIPTION
## 📝 작업 내용

- Refresh Token 저장방식 (쿠키 -> 헤더) 
    - "X-REFRESH-TOKEN" 
- AuthController Response 통일
- FilterException Response 통일
 

![스크린샷 2024-12-01 오후 7 52 36](https://github.com/user-attachments/assets/51071f36-1d02-4c70-a179-94992d9bd5ed)

## 💬 리뷰 요구사항(선택)

> 없어여. 정상작동만 확인하면 될듯
