### PR TITLE
[SC-90] RateLimit 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	// web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// bucket4j
+	implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core:7.5.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/inu/codin/codin/common/config/Bucket4jRateLimitApp.java
+++ b/src/main/java/inu/codin/codin/common/config/Bucket4jRateLimitApp.java
@@ -1,0 +1,22 @@
+package inu.codin.codin.common.config;
+
+import inu.codin.codin.common.ratelimit.RateLimitInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class Bucket4jRateLimitApp implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor interceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.
+                addInterceptor(interceptor).
+                addPathPatterns("/**")
+                .excludePathPatterns("/swagger-ui.html", "/swagger-resources/**", "/v2/api-docs", "/webjars/**");
+    }
+}

--- a/src/main/java/inu/codin/codin/common/ratelimit/ClientIpUtil.java
+++ b/src/main/java/inu/codin/codin/common/ratelimit/ClientIpUtil.java
@@ -1,0 +1,31 @@
+package inu.codin.codin.common.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Arrays;
+
+public class ClientIpUtil {
+    private static final String[] IP_HEADER_CANDIDATES = {
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_FORWARDED_FOR",
+            "HTTP_FORWARDED",
+            "HTTP_VIA",
+            "REMOTE_ADDR"
+    };
+
+    public static String getClientIp(HttpServletRequest request) {
+        for (String header : IP_HEADER_CANDIDATES) {
+            String ip = request.getHeader(header);
+            if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
+                return ip.split(",")[0].trim();
+            }
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/inu/codin/codin/common/ratelimit/RateLimitBucketConstants.java
+++ b/src/main/java/inu/codin/codin/common/ratelimit/RateLimitBucketConstants.java
@@ -1,0 +1,18 @@
+package inu.codin.codin.common.ratelimit;
+
+import java.time.Duration;
+
+/**
+ * @apiNote # BUCKET_CAPACITY : 토큰 버킷의 최대 용량
+ *          # BUCKET_TOKEN : 토큰 버킷의 현재 토큰 개수
+ *          # REFILL_DURATION : 토큰 버킷이 채워지는 주기
+ *          # REQUEST_PER_COST : 요청당 필요한 토큰 개수
+ */
+public class RateLimitBucketConstants {
+
+    public static final long BUCKET_CAPACITY = 10L;
+    public static final long BUCKET_TOKEN = 10L;
+    public static final Duration REFILL_DURATION = Duration.ofSeconds(1);
+    public static final long REQUEST_PER_COST = 1L;
+
+}

--- a/src/main/java/inu/codin/codin/common/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/inu/codin/codin/common/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,66 @@
+package inu.codin.codin.common.ratelimit;
+
+import inu.codin.codin.common.response.RateLimitResponse;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static inu.codin.codin.common.ratelimit.RateLimitBucketConstants.*;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Reference : https://velog.io/@whcksdud8/%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-Rate-limit-%ED%95%B8%EB%93%A4%EB%A7%81-%EB%B0%8F-%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    // todo : Redis로 변경
+    private final Map<String, Bucket> cache = new ConcurrentHashMap<>();
+    private final RateLimitService rateLimitService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String clientIp = ClientIpUtil.getClientIp(request);
+        Bucket bucket = cache.computeIfAbsent(clientIp, key -> createNewBucket());
+        ConsumptionProbe consumptionProbe = bucket.tryConsumeAndReturnRemaining(REQUEST_PER_COST);
+
+        if (isRateLimitExceeded(request, response, clientIp, consumptionProbe)) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isRateLimitExceeded(HttpServletRequest request, HttpServletResponse response, String clientIp, ConsumptionProbe consumptionProbe) {
+
+        if (consumptionProbe.isConsumed()) {
+            log.info("IP: {}, remaining tokens: {}", clientIp, consumptionProbe.getRemainingTokens());
+            RateLimitResponse.successResponse(response, consumptionProbe.getRemainingTokens(), BUCKET_CAPACITY, REFILL_DURATION);
+            return false;
+        } else {
+            log.warn("IP: {}, rate limit exceeded", clientIp);
+            RateLimitResponse.errorResponse(response, BUCKET_CAPACITY, REFILL_DURATION, 1);
+            rateLimitService.isLimitReachedThreshold(clientIp);
+            return true;
+        }
+    }
+
+    private Bucket createNewBucket() {
+        return Bucket.builder()
+                .addLimit(Bandwidth.classic(
+                        BUCKET_CAPACITY,
+                        Refill.intervally(BUCKET_TOKEN, REFILL_DURATION)
+                ))
+                .build();
+    }
+}

--- a/src/main/java/inu/codin/codin/common/ratelimit/RateLimitService.java
+++ b/src/main/java/inu/codin/codin/common/ratelimit/RateLimitService.java
@@ -1,0 +1,80 @@
+package inu.codin.codin.common.ratelimit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RateLimitService {
+
+    // IP 별로 요청 횟수를 저장하는 Map
+    private Map<String, RequestInfo> rateLimitErrorCounter = new ConcurrentHashMap<>();
+
+    public boolean isLimitReachedThreshold(String clientIp) {
+        RequestInfo requestInfo = rateLimitErrorCounter.computeIfAbsent(clientIp, key -> new RequestInfo());
+        if (!isApplyHandling(clientIp, requestInfo)) {
+            requestInfo.saveCount();
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isApplyHandling(String clientIp, RequestInfo requestInfo) {
+        if (requestInfo.isWithinTimeWindow()) {
+            int count = requestInfo.incrementCount();
+            log.info("IP: {}, remaining tokens: {}", clientIp, count);
+            checkAndResetIfLimitExceeded(clientIp, requestInfo, count);
+            return true;
+        }
+        return false;
+    }
+
+    private void checkAndResetIfLimitExceeded(String clientIp, RequestInfo requestInfo, int count) {
+        if (count >= 10) {
+            log.warn("IP: {}, rate limit exceeded, Count : {}", clientIp, count);
+            requestInfo.resetCount();
+            // todo : 지속적으로 rate limit을 넘는 IP Ban 처리 또는 계정 Ban 처리 필요.
+        }
+    }
+
+    private static class RequestInfo {
+        private AtomicInteger count = new AtomicInteger(0);
+        private LocalDateTime lastRequestTime;
+
+        // 요청 횟수 증가
+        public int incrementCount() {
+            return this.count.incrementAndGet();
+        }
+
+        // 1시간 이내에 요청이 있는지 확인
+        public boolean isWithinTimeWindow() {
+            LocalDateTime now = LocalDateTime.now();
+            if (this.lastRequestTime == null || ChronoUnit.HOURS.between(this.lastRequestTime, now) >= 1) {
+                this.lastRequestTime = now;
+                return false;
+            }
+            return true;
+        }
+
+        // 요청 횟수 초기화
+        public void saveCount() {
+            this.count.set(1);
+            lastRequestTime = LocalDateTime.now();
+        }
+
+        // 요청 횟수 초기화
+        public void resetCount() {
+            this.count.set(0);
+            lastRequestTime = LocalDateTime.now();
+        }
+    }
+
+}

--- a/src/main/java/inu/codin/codin/common/response/RateLimitResponse.java
+++ b/src/main/java/inu/codin/codin/common/response/RateLimitResponse.java
@@ -1,0 +1,20 @@
+package inu.codin.codin.common.response;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+
+import java.time.Duration;
+
+public class RateLimitResponse {
+
+    public static void successResponse(HttpServletResponse response, long remainToken, Long bucketCapacity, Duration callsInSeconds) {
+        response.setHeader("X-RateLimit-Remaining", Long.toString(remainToken));
+        response.setHeader("X-RateLimit-Limit", bucketCapacity + ";w=" + callsInSeconds.getSeconds());
+    }
+
+    public static void errorResponse(HttpServletResponse response, Long bucketCapacity, Duration callsInSeconds, float waitForRefill) {
+//        response.setHeader("X-RateLimit-Retry-After", Float.toString(waitForRefill));
+        response.setHeader("X-RateLimit-Limit", bucketCapacity + ";w=" + callsInSeconds.getSeconds());
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

- Gradle bucket4j 라이브러리 추가
- common.response 패키지에 새로운 RateLimitResponse 추가
- 같은 IP에 대하여 1초에 10개의 패킷 수용가능 나머지 패킷은 폐기됨. (아래의 스크린샷 참조)
- 작동방식 : (Filter -> Interceptor -> controller)
- Reference 
  - https://www.baeldung.com/spring-bucket4j
  - https://velog.io/@whcksdud8/%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-Rate-limit-%ED%95%B8%EB%93%A4%EB%A7%81-%EB%B0%8F-%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81

### 스크린샷
---
### RateLimit 미적용시 ErroRate 0%
![RateLimit 미적용시 ErroRate 0%](https://github.com/user-attachments/assets/6263eec2-574b-4236-9f88-14cb1695351e)
### RateLimit 미적용시 ErroRate 50%
![RateLimit 미적용시 ErroRate 50%](https://github.com/user-attachments/assets/2c1b1421-869f-48f3-9bcb-b4483fc55e3f)
### SpringBoot 로그
![스크린샷 2024-12-02 오후 8 33 50](https://github.com/user-attachments/assets/d701dac1-480a-4eeb-87af-a393a366e559)

## 💬 리뷰 요구사항

- 동시성 문제 때문에 CocurrentHashMap으로 데이터 저장.
  - 추후 Redis로 대체 필요.
- 계속 Rate Limit을 넘는 IP가 있을시에 해당 IP를 벤하거나, 계정을 정지하는 로직 추가 필요.
- Postman Collection Runner를 통해서 위와 같은 Test를 진행하였음.
