### PR TITLE
Refactor/sc 91 code refactor

### DIFF
--- a/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
@@ -23,7 +23,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(JwtException.class)
-    protected ResponseEntity<ExceptionResponse> handleJwtException(NotFoundException e) {
+    protected ResponseEntity<ExceptionResponse> handleJwtException(JwtException e) {
+        if (e.getErrorCode().getErrorCode().equals("SEC_005")){
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ExceptionResponse(e.getMessage(), HttpStatus.FORBIDDEN.value()));
+        }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(new ExceptionResponse(e.getMessage(), HttpStatus.UNAUTHORIZED.value()));
     }

--- a/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package inu.codin.codin.common.exception;
 
 import inu.codin.codin.common.response.ExceptionResponse;
+import inu.codin.codin.common.security.exception.JwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -19,6 +20,12 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ExceptionResponse> handleNotFoundException(NotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ExceptionResponse(e.getMessage(), HttpStatus.NOT_FOUND.value()));
+    }
+
+    @ExceptionHandler(JwtException.class)
+    protected ResponseEntity<ExceptionResponse> handleJwtException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ExceptionResponse(e.getMessage(), HttpStatus.UNAUTHORIZED.value()));
     }
 
 }

--- a/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
@@ -17,7 +17,7 @@ public class SecurityUtils {
      * 현재 인증된 사용자의 ID를 반환.
      *
      * @return 인증된 사용자의 ID
-     * @throws IllegalStateException 인증 정보가 없는 경우 예외 발생
+     * @throws JwtException 인증 정보가 없는 경우 예외 발생
      */
     public static ObjectId getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -37,6 +37,13 @@ public class SecurityUtils {
         }
 
         return userDetails.getRole();
+    }
+
+    public void validateUser(ObjectId id){
+        ObjectId userId = SecurityUtils.getCurrentUserId();
+        if (!id.equals(userId)) {
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "현재 유저에게 권한이 없습니다.");
+        }
     }
 
 }

--- a/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
@@ -2,6 +2,7 @@ package inu.codin.codin.common.security.util;
 
 import inu.codin.codin.common.security.exception.JwtException;
 import inu.codin.codin.common.security.exception.SecurityErrorCode;
+import inu.codin.codin.domain.user.entity.UserRole;
 import inu.codin.codin.domain.user.security.CustomUserDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,6 +26,16 @@ public class SecurityUtils {
         }
 
         return userDetails.getId();
+    }
+
+    public static UserRole getCurrentUserRole(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
+            throw new JwtException(SecurityErrorCode.INVALID_CREDENTIALS);
+        }
+
+        return userDetails.getRole();
     }
 
 }

--- a/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
@@ -4,6 +4,7 @@ import inu.codin.codin.common.security.exception.JwtException;
 import inu.codin.codin.common.security.exception.SecurityErrorCode;
 import inu.codin.codin.domain.user.entity.UserRole;
 import inu.codin.codin.domain.user.security.CustomUserDetails;
+import org.bson.types.ObjectId;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -18,7 +19,7 @@ public class SecurityUtils {
      * @return 인증된 사용자의 ID
      * @throws IllegalStateException 인증 정보가 없는 경우 예외 발생
      */
-    public static String getCurrentUserId() {
+    public static ObjectId getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {

--- a/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
@@ -23,7 +23,7 @@ public class SecurityUtils {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
-            throw new JwtException(SecurityErrorCode.INVALID_CREDENTIALS);
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED);
         }
 
         return userDetails.getId();
@@ -33,7 +33,7 @@ public class SecurityUtils {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
-            throw new JwtException(SecurityErrorCode.INVALID_CREDENTIALS);
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED);
         }
 
         return userDetails.getRole();

--- a/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailCheckRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailCheckRequestDto.java
@@ -3,13 +3,13 @@ package inu.codin.codin.domain.email.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Data;
+import lombok.Getter;
 
 /**
  * 이메일 인증 코드 확인 요청 DTO
  * 해당 이메일로 전송된 인증 코드를 확인한다.
  */
-@Data
+@Getter
 public class JoinEmailCheckRequestDto {
 
     @Schema(description = "이메일 주소", example = "example@inu.ac.kr")

--- a/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailSendRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/email/dto/JoinEmailSendRequestDto.java
@@ -3,13 +3,13 @@ package inu.codin.codin.domain.email.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Data;
+import lombok.Getter;
 
 /**
  * 이메일 인증 코드 전송 요청 DTO
  * 해당 이메일로 인증 코드를 전송한다.
  */
-@Data
+@Getter
 public class JoinEmailSendRequestDto {
 
     @Schema(description = "이메일 주소", example = "example@inu.ac.kr")

--- a/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
+++ b/src/main/java/inu/codin/codin/domain/email/entity/EmailAuthEntity.java
@@ -4,6 +4,7 @@ import inu.codin.codin.common.BaseTimeEntity;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 public class EmailAuthEntity extends BaseTimeEntity {
 
     @Id @NotBlank
-    private String id;
+    private ObjectId _id;
 
     @NotBlank
     private String email;

--- a/src/main/java/inu/codin/codin/domain/email/repository/EmailAuthRepository.java
+++ b/src/main/java/inu/codin/codin/domain/email/repository/EmailAuthRepository.java
@@ -1,13 +1,14 @@
 package inu.codin.codin.domain.email.repository;
 
 import inu.codin.codin.domain.email.entity.EmailAuthEntity;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface EmailAuthRepository extends MongoRepository<EmailAuthEntity, String> {
+public interface EmailAuthRepository extends MongoRepository<EmailAuthEntity, ObjectId> {
 
     Optional<EmailAuthEntity> findByEmail(String email);
 

--- a/src/main/java/inu/codin/codin/domain/info/domain/lab/dto/response/LabListResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/lab/dto/response/LabListResponseDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.bson.types.ObjectId;
 
 /*
     연구실 리스트 반환 DTO
@@ -40,7 +41,7 @@ public class LabListResponseDto {
 
     public static LabListResponseDto of(Lab lab){
         return LabListResponseDto.builder()
-                .id(lab.getId())
+                .id(lab.get_id().toString())
                 .title(lab.getTitle())
                 .content(lab.getContent())
                 .professor(lab.getProfessor())

--- a/src/main/java/inu/codin/codin/domain/info/domain/lab/dto/response/LabThumbnailResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/lab/dto/response/LabThumbnailResponseDto.java
@@ -18,33 +18,33 @@ public class LabThumbnailResponseDto {
 
     @NotBlank
     @Schema(description = "학과", example = "EMBEDDED")
-    private Department department;
+    private final Department department;
 
     @NotBlank
     @Schema(description = "연구실 이름", example = "땡땡연구실")
-    private String title;
+    private final String title;
 
     @Schema(description = "연구 내용", example = "이것저것 연구합니다.")
-    private String content;
+    private final String content;
 
     @NotBlank
     @Schema(description = "담당 교수", example = "홍길동")
-    private String professor;
+    private final String professor;
 
     @Schema(description = "교수실 위치", example = "7호관 423호")
-    private String professorLoc;
+    private final String professorLoc;
 
     @Schema(description = "교수실 전화번호", example = "032-123-4567")
-    private String professorNumber;
+    private final String professorNumber;
 
     @Schema(description = "연구실 위치", example = "7호관 409호")
-    private String labLoc;
+    private final String labLoc;
 
     @Schema(description = "연구실 전화번호", example = "032-987-0653")
-    private String labNumber;
+    private final String labNumber;
 
     @Schema(description = "연구실 홈페이지", example = "http://~")
-    private String site;
+    private final String site;
 
     @Builder
     public LabThumbnailResponseDto(Department department, String title, String content, String professor,

--- a/src/main/java/inu/codin/codin/domain/info/domain/lab/entity/Lab.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/lab/entity/Lab.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "info")
@@ -35,7 +36,7 @@ public class Lab extends Info {
     private String site;
 
     @Builder
-    public Lab(String id, Department department, InfoType infoType, String professor, String title, String content, String professorLoc, String professorNumber, String labLoc, String labNumber, String site) {
+    public Lab(ObjectId id, Department department, InfoType infoType, String professor, String title, String content, String professorLoc, String professorNumber, String labLoc, String labNumber, String site) {
         super(id, department, infoType);
         this.professor = professor;
         this.title = title;

--- a/src/main/java/inu/codin/codin/domain/info/domain/lab/service/LabService.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/lab/service/LabService.java
@@ -7,6 +7,7 @@ import inu.codin.codin.domain.info.domain.lab.entity.Lab;
 import inu.codin.codin.domain.info.domain.lab.exception.LabNotFoundException;
 import inu.codin.codin.domain.info.repository.InfoRepository;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,7 +19,7 @@ public class LabService {
     private final InfoRepository infoRepository;
 
     public LabThumbnailResponseDto getLabThumbnail(String id) {
-        Lab lab = infoRepository.findLabById(id)
+        Lab lab = infoRepository.findLabById(new ObjectId(id))
                 .orElseThrow(() -> new LabNotFoundException("연구실 정보를 찾을 수 없습니다."));
         return LabThumbnailResponseDto.of(lab);
     }
@@ -35,14 +36,14 @@ public class LabService {
     }
 
     public void updateLab(LabCreateUpdateRequestDto labCreateUpdateRequestDto, String id) {
-        Lab lab = infoRepository.findLabById(id)
+        Lab lab = infoRepository.findLabById(new ObjectId(id))
                 .orElseThrow(() -> new LabNotFoundException("연구실 정보를 찾을 수 없습니다."));
         lab.update(labCreateUpdateRequestDto);
         infoRepository.save(lab);
     }
 
     public void deleteLab(String id) {
-        Lab lab = infoRepository.findLabById(id)
+        Lab lab = infoRepository.findLabById(new ObjectId(id))
                 .orElseThrow(() -> new LabNotFoundException("연구실 정보를 찾을 수 없습니다."));
         lab.delete();
         infoRepository.save(lab);

--- a/src/main/java/inu/codin/codin/domain/info/domain/office/dto/request/OfficeMemberCreateUpdateRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/office/dto/request/OfficeMemberCreateUpdateRequestDto.java
@@ -3,10 +3,8 @@ package inu.codin.codin.domain.info.domain.office.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class OfficeMemberCreateUpdateRequestDto {
     @NotBlank
     @Schema(description = "성명", example = "홍길동")

--- a/src/main/java/inu/codin/codin/domain/info/domain/office/dto/request/OfficeUpdateRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/office/dto/request/OfficeUpdateRequestDto.java
@@ -5,10 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class OfficeUpdateRequestDto {
 
     @Schema(description = "위치", example = "7호관 329호")

--- a/src/main/java/inu/codin/codin/domain/info/domain/office/dto/response/OfficeDetailsResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/office/dto/response/OfficeDetailsResponseDto.java
@@ -15,7 +15,6 @@ import java.util.List;
     학과 사무실 평면도 및 지원 정보들을 모두 반환한다.
  */
 @Getter
-@Setter
 public class OfficeDetailsResponseDto {
 
     @Schema(description = "학과", example = "IT_COLLEGE")
@@ -41,10 +40,10 @@ public class OfficeDetailsResponseDto {
     private final String fax;
 
     @Schema(description = "사무실 평면도", example = "https://")
-    private String img;
+    private final String img;
 
     @Schema(description = "학과사무실 직원")
-    private List<OfficeMemberResponseDto> officeMember;
+    private final List<OfficeMemberResponseDto> officeMember;
 
     @Builder
     public OfficeDetailsResponseDto(Department department, String location, String open, String vacation, String officeNumber, String fax, String img, List<OfficeMemberResponseDto> officeMember) {

--- a/src/main/java/inu/codin/codin/domain/info/domain/office/dto/response/OfficeMemberResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/office/dto/response/OfficeMemberResponseDto.java
@@ -13,21 +13,21 @@ import lombok.Getter;
 public class OfficeMemberResponseDto {
     @NotBlank
     @Schema(description = "성명", example = "홍길동")
-    private String name;
+    private final String name;
     @NotBlank
     @Schema(description = "직위", example = "조교")
-    private String position;
+    private final String position;
 
     @Schema(description = "담당 업무", example = "학과사무실 업무")
-    private String role;
+    private final String role;
 
     @NotBlank
     @Schema(description = "연락처", example = "032-123-2345")
-    private String number;
+    private final String number;
 
     @NotBlank
     @Schema(description = "이메일", example = "test@inu.ac.kr")
-    private String email;
+    private final String email;
 
     @Builder
     public OfficeMemberResponseDto(String name, String position, String role, String number, String email) {

--- a/src/main/java/inu/codin/codin/domain/info/domain/professor/dto/request/ProfessorCreateUpdateRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/professor/dto/request/ProfessorCreateUpdateRequestDto.java
@@ -4,42 +4,48 @@ import inu.codin.codin.common.Department;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
 public class ProfessorCreateUpdateRequestDto {
 
         @NotNull
         @Schema(description = "학과", example = "COMPUTER_SCI")
-        Department department;
+        private Department department;
 
         @NotBlank @Schema(description = "성함", example = "홍길동")
-        String name;
+        private String name;
 
         @NotBlank @Schema(description = "프로필 사진", example = "https://~")
-        String image;
+        private String image;
 
         @NotBlank @Schema(description = "전화번호", example = "032-123-4567")
-        String number;
+        private String number;
 
         @NotBlank @Schema(description = "이메일", example = "test@inu.ac.kr")
-        String email;
+        private String email;
 
         @Schema(description = "연구실 홈페이지", example = "https://~")
-        String site;
+        private String site;
 
         @Schema(description = "연구 분야", example = "무선 통신 및 머신런닝")
-        String field;
+        private String field;
 
         @Schema(description = "담당 과목", example = "대학수학, 이동통신, ..")
-        String subject;
+        private String subject;
 
         @Schema(description = "연구실 _id", example = "6731a506c4ee25b3adf593ca")
-        String labId;
+        private String labId;
+
+        public ProfessorCreateUpdateRequestDto(Department department, String name, String image, String number, String email, String site, String field, String subject, String labId) {
+                this.department = department;
+                this.name = name;
+                this.image = image;
+                this.number = number;
+                this.email = email;
+                this.site = site;
+                this.field = field;
+                this.subject = subject;
+                this.labId = labId;
+        }
 }

--- a/src/main/java/inu/codin/codin/domain/info/domain/professor/dto/response/ProfessorListResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/professor/dto/response/ProfessorListResponseDto.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.bson.types.ObjectId;
 
 /*
     교수님 리스트 반환 DTO
@@ -34,7 +35,7 @@ public class ProfessorListResponseDto{
 
     public static ProfessorListResponseDto of(Professor professor) {
         return ProfessorListResponseDto.builder()
-                .id(professor.getId())
+                .id(professor.get_id().toString())
                 .name(professor.getName())
                 .department(professor.getDepartment())
                 .build();

--- a/src/main/java/inu/codin/codin/domain/info/domain/professor/dto/response/ProfessorListResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/professor/dto/response/ProfessorListResponseDto.java
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
-import org.bson.types.ObjectId;
 
 /*
     교수님 리스트 반환 DTO
@@ -15,27 +13,26 @@ import org.bson.types.ObjectId;
  */
 
 @Getter
-@Setter
 public class ProfessorListResponseDto{
     @NotBlank @Schema(description = "교수 _id", example = "67319fe3c4ee25b3adf593a0")
-    String id;
+    private final String _id;
 
     @NotBlank @Schema(description = "교수 성함", example = "홍길동")
-    String name;
+    private final String name;
 
     @NotBlank @Schema(description = "학과", example = "CSE")
-    Department department;
+    private final Department department;
 
     @Builder
-    public ProfessorListResponseDto(String id, String name, Department department) {
-        this.id = id;
+    public ProfessorListResponseDto(String _id, String name, Department department) {
+        this._id = _id;
         this.name = name;
         this.department = department;
     }
 
     public static ProfessorListResponseDto of(Professor professor) {
         return ProfessorListResponseDto.builder()
-                .id(professor.get_id().toString())
+                ._id(professor.get_id().toString())
                 .name(professor.getName())
                 .department(professor.getDepartment())
                 .build();

--- a/src/main/java/inu/codin/codin/domain/info/domain/professor/dto/response/ProfessorThumbnailResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/professor/dto/response/ProfessorThumbnailResponseDto.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 /*
     교수님 상세 정보 반환 DTO
@@ -14,27 +13,26 @@ import lombok.Setter;
  */
 
 @Getter
-@Setter
 public class ProfessorThumbnailResponseDto{
 
     @NotBlank @Schema(description = "학과", example = "CSE")
-    Department department;
+    private final Department department;
     @NotBlank @Schema(description = "성함", example = "홍길동")
-    String name;
+    private final String name;
     @NotBlank @Schema(description = "프로필 사진", example = "https://~")
-    String image;
+    private final String image;
     @NotBlank @Schema(description = "전화번호", example = "032-123-4567")
-    String number;
+    private final String number;
     @NotBlank @Schema(description = "이메일", example = "test@inu.ac.kr")
-    String email;
+    private final String email;
     @Schema(description = "연구실 홈페이지", example = "https://~")
-    String site;
+    private final String site;
     @Schema(description = "연구 분야", example = "무선 통신 및 머신런닝")
-    String field;
+    private final String field;
     @Schema(description = "담당 과목", example = "대학수학, 이동통신, ..")
-    String subject;
+    private final String subject;
     @Schema(description = "연구실 _id", example = "6731a506c4ee25b3adf593ca")
-    String labId;
+    private final String labId;
 
     @Builder
     public ProfessorThumbnailResponseDto(Department department, String name, String image, String number, String email, String site, String field, String subject, String labId) {

--- a/src/main/java/inu/codin/codin/domain/info/domain/professor/entity/Professor.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/professor/entity/Professor.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "info")
@@ -38,7 +39,7 @@ public class Professor extends Info {
     private String labId;
 
     @Builder
-    public Professor(String id, Department department, InfoType infoType, String name, String image, String number, String email, String site, String field, String subject, String labId) {
+    public Professor(ObjectId id, Department department, InfoType infoType, String name, String image, String number, String email, String site, String field, String subject, String labId) {
         super(id, department, infoType);
         this.name = name;
         this.image = image;

--- a/src/main/java/inu/codin/codin/domain/info/domain/professor/service/ProfessorService.java
+++ b/src/main/java/inu/codin/codin/domain/info/domain/professor/service/ProfessorService.java
@@ -9,6 +9,7 @@ import inu.codin.codin.domain.info.domain.professor.exception.ProfessorDuplicate
 import inu.codin.codin.domain.info.domain.professor.exception.ProfessorNotFoundException;
 import inu.codin.codin.domain.info.repository.InfoRepository;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -25,7 +26,7 @@ public class ProfessorService {
     }
 
     public ProfessorThumbnailResponseDto getProfessorThumbnail(String id) {
-        Professor professor = infoRepository.findProfessorById(id)
+        Professor professor = infoRepository.findProfessorById(new ObjectId(id))
                 .orElseThrow(() -> new ProfessorNotFoundException("교수 정보를 찾을 수 없습니다."));
         return ProfessorThumbnailResponseDto.of(professor);
     }
@@ -39,7 +40,7 @@ public class ProfessorService {
     }
 
     public void updateProfessor(String id, ProfessorCreateUpdateRequestDto professorCreateUpdateRequestDto) {
-        Professor professor = infoRepository.findProfessorById(id)
+        Professor professor = infoRepository.findProfessorById(new ObjectId(id))
                 .orElseThrow(() -> new ProfessorNotFoundException("교수 정보를 찾을 수 없습니다."));
         professor.update(professorCreateUpdateRequestDto);
         infoRepository.save(professor);
@@ -48,7 +49,7 @@ public class ProfessorService {
 
 
     public void deleteProfessor(String id) {
-        Professor professor = infoRepository.findProfessorById(id)
+        Professor professor = infoRepository.findProfessorById(new ObjectId(id))
                 .orElseThrow(() -> new ProfessorNotFoundException("교수 정보를 찾을 수 없습니다."));
         professor.delete();
         infoRepository.save(professor);

--- a/src/main/java/inu/codin/codin/domain/info/entity/Info.java
+++ b/src/main/java/inu/codin/codin/domain/info/entity/Info.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -15,7 +16,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public abstract class Info extends BaseTimeEntity {
 
     @Id @NotBlank
-    protected String id;
+    protected ObjectId _id;
 
     @NotBlank
     protected Department department;
@@ -23,8 +24,8 @@ public abstract class Info extends BaseTimeEntity {
     @NotBlank
     protected InfoType infoType;
 
-    public Info(String id, Department department, InfoType infoType) {
-        this.id = id;
+    public Info(ObjectId id, Department department, InfoType infoType) {
+        this._id = id;
         this.department = department;
         this.infoType = infoType;
     }

--- a/src/main/java/inu/codin/codin/domain/info/repository/InfoRepository.java
+++ b/src/main/java/inu/codin/codin/domain/info/repository/InfoRepository.java
@@ -5,22 +5,20 @@ import inu.codin.codin.domain.info.domain.lab.entity.Lab;
 import inu.codin.codin.domain.info.domain.office.entity.Office;
 import inu.codin.codin.domain.info.domain.professor.entity.Professor;
 import inu.codin.codin.domain.info.entity.Info;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface InfoRepository extends MongoRepository<Info, String> {
+public interface InfoRepository extends MongoRepository<Info, ObjectId> {
 
     @Query("{ 'infoType': 'LAB', 'deletedAt': null }")
     List<Lab> findAllLabs();
 
     @Query("{ 'infoType': 'LAB', '_id': ?0, 'deletedAt': null }")
-    Optional<Lab> findLabById(String id);
-
-    @Query("{ 'infoType': 'OFFICE', 'deletedAt': null }")
-    List<Office> findAllOffices();
+    Optional<Lab> findLabById(ObjectId id);
 
     @Query("{ 'infoType': 'OFFICE', 'department': ?0, 'deletedAt': null }")
     Office findOfficeByDepartment(Department department);
@@ -29,7 +27,7 @@ public interface InfoRepository extends MongoRepository<Info, String> {
     List<Professor> findAllProfessorsByDepartment(Department department);
 
     @Query("{ 'infoType': 'PROFESSOR', '_id': ?0, 'deletedAt': null }")
-    Optional<Professor> findProfessorById(String id);
+    Optional<Professor> findProfessorById(ObjectId id);
 
     @Query("{ 'infoType': 'PROFESSOR', 'email': ?0, 'deletedAt': null }")
     Optional<Professor> findProfessorByEmail(String email);

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/controller/CommentController.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/controller/CommentController.java
@@ -2,8 +2,8 @@ package inu.codin.codin.domain.post.domain.comment.controller;
 
 import inu.codin.codin.common.response.ListResponse;
 import inu.codin.codin.common.response.SingleResponse;
-import inu.codin.codin.domain.post.domain.comment.dto.CommentCreateRequestDTO;
-import inu.codin.codin.domain.post.domain.comment.dto.CommentResponseDTO;
+import inu.codin.codin.domain.post.domain.comment.dto.request.CommentCreateRequestDTO;
+import inu.codin.codin.domain.post.domain.comment.dto.response.CommentResponseDTO;
 import inu.codin.codin.domain.post.domain.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/dto/CommentCreateRequestDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/dto/CommentCreateRequestDTO.java
@@ -3,12 +3,12 @@ package inu.codin.codin.domain.post.domain.comment.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 public class CommentCreateRequestDTO {
-//    @Schema(description = "유저 ID", example = "111111")
-//    @NotBlank
-//    private String userId;
 
     @Schema(description = "댓글 내용", example = "content")
     @NotBlank

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/dto/CommentResponseDTO.java
@@ -3,14 +3,17 @@ package inu.codin.codin.domain.post.domain.comment.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.bson.types.ObjectId;
 
 import java.util.List;
 
-@Data
+@Getter
 public class CommentResponseDTO {
     @Schema(description = "댓글 또는 대댓글 ID", example = "111111")
     @NotBlank
-    private String commentId;
+    private String _id;
 
     @Schema(description = "유저 ID", example = "user123")
     @NotBlank
@@ -29,8 +32,8 @@ public class CommentResponseDTO {
     @Schema(description = "삭제 여부", example = "false")
     private boolean isDeleted;
 
-    public CommentResponseDTO(String commentId, String userId, String content, List<CommentResponseDTO> replies, int likeCount, boolean isDeleted) {
-        this.commentId = commentId;
+    public CommentResponseDTO(String _id, String userId, String content, List<CommentResponseDTO> replies, int likeCount, boolean isDeleted) {
+        this._id = _id;
         this.userId = userId;
         this.content = content;
         this.replies = replies;

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/dto/request/CommentCreateRequestDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/dto/request/CommentCreateRequestDTO.java
@@ -1,13 +1,10 @@
-package inu.codin.codin.domain.post.domain.comment.dto;
+package inu.codin.codin.domain.post.domain.comment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Data;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class CommentCreateRequestDTO {
 
     @Schema(description = "댓글 내용", example = "content")

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/dto/response/CommentResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/dto/response/CommentResponseDTO.java
@@ -1,11 +1,8 @@
-package inu.codin.codin.domain.post.domain.comment.dto;
+package inu.codin.codin.domain.post.domain.comment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Data;
 import lombok.Getter;
-import lombok.Setter;
-import org.bson.types.ObjectId;
 
 import java.util.List;
 
@@ -13,24 +10,24 @@ import java.util.List;
 public class CommentResponseDTO {
     @Schema(description = "댓글 또는 대댓글 ID", example = "111111")
     @NotBlank
-    private String _id;
+    private final String _id;
 
     @Schema(description = "유저 ID", example = "user123")
     @NotBlank
-    private String userId;
+    private final String userId;
 
     @Schema(description = "댓글 또는 대댓글 내용", example = "This is a comment.")
     @NotBlank
-    private String content;
+    private final String content;
 
     @Schema(description = "대댓글 리스트", example = "[...]")
-    private List<CommentResponseDTO> replies;
+    private final List<CommentResponseDTO> replies;
 
     @Schema(description = "좋아요 수", example = "5")
-    private int likeCount;
+    private final int likeCount;
 
     @Schema(description = "삭제 여부", example = "false")
-    private boolean isDeleted;
+    private final boolean isDeleted;
 
     public CommentResponseDTO(String _id, String userId, String content, List<CommentResponseDTO> replies, int likeCount, boolean isDeleted) {
         this._id = _id;

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/entity/CommentEntity.java
@@ -4,6 +4,7 @@ import inu.codin.codin.common.BaseTimeEntity;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -11,17 +12,17 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Getter
 public class CommentEntity extends BaseTimeEntity {
     @Id @NotBlank
-    private String commentId;
+    private ObjectId _id;
 
-    private String postId;  //게시글 ID 참조
-    private String userId;
+    private ObjectId postId;  //게시글 ID 참조
+    private ObjectId userId;
     private String content;
 
     private int likeCount = 0;  // 좋아요 수 (Redis에서 관리)
 
     @Builder
-    public CommentEntity(String commentId, String postId, String userId, String content) {
-        this.commentId = commentId;
+    public CommentEntity(ObjectId _id, ObjectId postId, ObjectId userId, String content) {
+        this._id = _id;
         this.postId = postId;
         this.userId = userId;
         this.content = content;

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/repository/CommentRepository.java
@@ -1,18 +1,19 @@
 package inu.codin.codin.domain.post.domain.comment.repository;
 
 import inu.codin.codin.domain.post.domain.comment.entity.CommentEntity;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface CommentRepository extends MongoRepository<CommentEntity, String> {
+public interface CommentRepository extends MongoRepository<CommentEntity, ObjectId> {
 
 
     @Query("{ '_id': ?0, 'deletedAt': null }")
-    Optional<CommentEntity> findByIdAndNotDeleted(String Id);
+    Optional<CommentEntity> findByIdAndNotDeleted(ObjectId Id);
 
     @Query("{ 'postId': ?0 }")
-    List<CommentEntity> findByPostId(String postId);
+    List<CommentEntity> findByPostId(ObjectId postId);
 }

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -2,8 +2,8 @@ package inu.codin.codin.domain.post.domain.comment.service;
 
 import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.common.security.util.SecurityUtils;
-import inu.codin.codin.domain.post.domain.comment.dto.CommentCreateRequestDTO;
-import inu.codin.codin.domain.post.domain.comment.dto.CommentResponseDTO;
+import inu.codin.codin.domain.post.domain.comment.dto.request.CommentCreateRequestDTO;
+import inu.codin.codin.domain.post.domain.comment.dto.response.CommentResponseDTO;
 import inu.codin.codin.domain.post.domain.comment.entity.CommentEntity;
 import inu.codin.codin.domain.post.domain.reply.service.ReplyCommentService;
 import inu.codin.codin.domain.post.entity.PostEntity;

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -15,6 +15,7 @@ import inu.codin.codin.domain.post.domain.comment.repository.CommentRepository;
 import inu.codin.codin.domain.post.domain.reply.repository.ReplyCommentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -32,11 +33,12 @@ public class CommentService {
     private final ReplyCommentService replyCommentService;
 
     // 댓글 추가
-    public void addComment(String postId, CommentCreateRequestDTO requestDTO) {
+    public void addComment(String id, CommentCreateRequestDTO requestDTO) {
+        ObjectId postId = new ObjectId(id);
         PostEntity post = postRepository.findByIdAndNotDeleted(postId)
                 .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
 
-        String userId = SecurityUtils.getCurrentUserId();
+        ObjectId userId = SecurityUtils.getCurrentUserId();
         CommentEntity comment = CommentEntity.builder()
                 .postId(postId)
                 .userId(userId)
@@ -51,7 +53,8 @@ public class CommentService {
     }
 
     // 댓글 삭제 (Soft Delete)
-    public void softDeleteComment(String commentId) {
+    public void softDeleteComment(String id) {
+        ObjectId commentId = new ObjectId(id);
         CommentEntity comment = commentRepository.findByIdAndNotDeleted(commentId)
                 .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
 
@@ -76,13 +79,14 @@ public class CommentService {
         postRepository.save(post);
 
         log.info("삭제된 commentId: {} , 대댓글 {} . 총 삭제 수: {} postId: {}",
-                commentId, replies.size(), (1 + replies.size()), post.getPostId());
+                commentId, replies.size(), (1 + replies.size()), post.get_id());
     }
 
 
 
     // 특정 게시물의 댓글 및 대댓글 조회
-    public List<CommentResponseDTO> getCommentsByPostId(String postId) {
+    public List<CommentResponseDTO> getCommentsByPostId(String id) {
+        ObjectId postId = new ObjectId(id);
         postRepository.findByIdAndNotDeleted(postId)
                 .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
         List<CommentEntity> comments = commentRepository.findByPostId(postId);
@@ -91,11 +95,11 @@ public class CommentService {
                 .map(comment -> {
                     boolean isDeleted = comment.getDeletedAt() != null;
                     return new CommentResponseDTO(
-                            comment.getCommentId(),
-                            comment.getUserId(),
+                            comment.get_id().toString(),
+                            comment.getUserId().toString(),
                             comment.getContent(),
-                            replyCommentService.getRepliesByCommentId(comment.getCommentId()), // 대댓글 조회
-                            likeService.getLikeCount(LikeType.valueOf("COMMENT"), comment.getCommentId()), // 댓글 좋아요 수
+                            replyCommentService.getRepliesByCommentId(comment.get_id()), // 대댓글 조회
+                            likeService.getLikeCount(LikeType.valueOf("COMMENT"), comment.get_id()), // 댓글 좋아요 수
                             isDeleted);
                     })
                 .toList();

--- a/src/main/java/inu/codin/codin/domain/post/domain/like/entity/LikeEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/like/entity/LikeEntity.java
@@ -3,6 +3,7 @@ package inu.codin.codin.domain.post.domain.like.entity;
 import inu.codin.codin.common.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -10,13 +11,13 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Getter
 public class LikeEntity extends BaseTimeEntity {
     @Id
-    private String id;
-    private String likeTypeId; // 게시글, 댓글, 대댓글의 ID
+    private ObjectId _id;
+    private ObjectId likeTypeId; // 게시글, 댓글, 대댓글의 ID
     private LikeType likeType; // 엔티티 타입 (post, comment, reply)
-    private String userId; // 좋아요를 누른 사용자 ID
+    private ObjectId userId; // 좋아요를 누른 사용자 ID
 
     @Builder
-    public LikeEntity(String likeTypeId, LikeType likeType, String userId) {
+    public LikeEntity(ObjectId likeTypeId, LikeType likeType, ObjectId userId) {
         this.likeTypeId = likeTypeId;
         this.likeType = likeType;
         this.userId = userId;

--- a/src/main/java/inu/codin/codin/domain/post/domain/like/repository/LikeRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/like/repository/LikeRepository.java
@@ -2,6 +2,7 @@ package inu.codin.codin.domain.post.domain.like.repository;
 
 import inu.codin.codin.domain.post.domain.like.entity.LikeEntity;
 import inu.codin.codin.domain.post.domain.like.entity.LikeType;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,15 +10,15 @@ import java.util.List;
 
 @Repository
 
-public interface LikeRepository extends MongoRepository<LikeEntity, String> {
+public interface LikeRepository extends MongoRepository<LikeEntity, ObjectId> {
     // 특정 엔티티(게시글/댓글/대댓글)의 좋아요 개수 조회
-    long countByLikeTypeAndLikeTypeId(LikeType likeType, String id);
+    long countByLikeTypeAndLikeTypeId(LikeType likeType, ObjectId id);
 
     // 특정 엔티티의 좋아요 데이터 조회
-    List<LikeEntity> findByLikeTypeAndLikeTypeId(LikeType likeType, String id);
+    List<LikeEntity> findByLikeTypeAndLikeTypeId(LikeType likeType, ObjectId id);
 
     // 특정 사용자의 좋아요 삭제
-    void deleteByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, String id, String userId);
+    void deleteByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, ObjectId id, ObjectId userId);
 
-    boolean existsByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, String id, String userId);
+    boolean existsByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, ObjectId id, ObjectId userId);
 }

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/dto/request/ReplyCreateRequestDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/dto/request/ReplyCreateRequestDTO.java
@@ -2,13 +2,10 @@ package inu.codin.codin.domain.post.domain.reply.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class ReplyCreateRequestDTO {
-//    @Schema(description = "유저 ID", example = "111111")
-//    @NotBlank
-//    private String userId;
 
     @Schema(description = "댓글 내용", example = "content")
     @NotBlank

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/entity/ReplyCommentEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/entity/ReplyCommentEntity.java
@@ -14,7 +14,6 @@ public class ReplyCommentEntity extends BaseTimeEntity {
     @Id
     @NotBlank
     private ObjectId _id;
-
     private ObjectId commentId; // 댓글 ID 참조
     private ObjectId userId; // 작성자 ID
     private String content;

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/entity/ReplyCommentEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/entity/ReplyCommentEntity.java
@@ -4,6 +4,7 @@ import inu.codin.codin.common.BaseTimeEntity;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -12,17 +13,17 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class ReplyCommentEntity extends BaseTimeEntity {
     @Id
     @NotBlank
-    private String replyId;
+    private ObjectId _id;
 
-    private String commentId; // 댓글 ID 참조
-    private String userId; // 작성자 ID
+    private ObjectId commentId; // 댓글 ID 참조
+    private ObjectId userId; // 작성자 ID
     private String content;
 
     private int likeCount = 0; // 좋아요 카운트
 
     @Builder
-    public ReplyCommentEntity(String replyId, String commentId, String userId, String content, int likeCount) {
-        this.replyId = replyId;
+    public ReplyCommentEntity(ObjectId _id, ObjectId commentId, ObjectId userId, String content, int likeCount) {
+        this._id = _id;
         this.commentId = commentId;
         this.userId = userId;
         this.content = content;

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/repository/ReplyCommentRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/repository/ReplyCommentRepository.java
@@ -2,17 +2,18 @@ package inu.codin.codin.domain.post.domain.reply.repository;
 
 
 import inu.codin.codin.domain.post.domain.reply.entity.ReplyCommentEntity;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface ReplyCommentRepository extends MongoRepository<ReplyCommentEntity, String> {
+public interface ReplyCommentRepository extends MongoRepository<ReplyCommentEntity, ObjectId> {
 
     @Query("{'_id': ?0, 'deletedAt': null}")
-    Optional<ReplyCommentEntity> findByIdAndNotDeleted(String id);
+    Optional<ReplyCommentEntity> findByIdAndNotDeleted(ObjectId id);
 
     @Query("{'commentId':  ?0, 'deletedAt':  null}")
-    List<ReplyCommentEntity> findByCommentIdAndNotDeleted(String commentId);
+    List<ReplyCommentEntity> findByCommentIdAndNotDeleted(ObjectId commentId);
 }

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -14,6 +14,7 @@ import inu.codin.codin.domain.post.entity.PostEntity;
 import inu.codin.codin.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -30,13 +31,14 @@ public class ReplyCommentService {
     private final LikeService likeService;
 
     // 대댓글 추가
-    public void addReply(String commentId, ReplyCreateRequestDTO requestDTO) {
+    public void addReply(String id, ReplyCreateRequestDTO requestDTO) {
+        ObjectId commentId = new ObjectId(id);
         CommentEntity comment = commentRepository.findByIdAndNotDeleted(commentId)
                 .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
         PostEntity post = postRepository.findByIdAndNotDeleted(comment.getPostId())
                 .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
 
-        String userId = SecurityUtils.getCurrentUserId();
+        ObjectId userId = SecurityUtils.getCurrentUserId();
 
         ReplyCommentEntity reply = ReplyCommentEntity.builder()
                 .commentId(commentId)
@@ -55,7 +57,7 @@ public class ReplyCommentService {
 
     // 대댓글 삭제 (Soft Delete)
     public void softDeleteReply(String replyId) {
-        ReplyCommentEntity reply = replyCommentRepository.findByIdAndNotDeleted(replyId)
+        ReplyCommentEntity reply = replyCommentRepository.findByIdAndNotDeleted(new ObjectId(replyId))
                 .orElseThrow(() -> new NotFoundException("대댓글을 찾을 수 없습니다."));
         // 대댓글 삭제
         reply.delete();
@@ -70,19 +72,19 @@ public class ReplyCommentService {
         post.updateCommentCount(post.getCommentCount() - 1);
         postRepository.save(post);
 
-        log.info("대댓글 성공적 삭제  replyId: {} , postId: {}.", replyId, post.getPostId());
+        log.info("대댓글 성공적 삭제  replyId: {} , postId: {}.", replyId, post.get_id());
     }
 
     // 특정 댓글의 대댓글 조회
-    public List<CommentResponseDTO> getRepliesByCommentId(String commentId) {
+    public List<CommentResponseDTO> getRepliesByCommentId(ObjectId commentId) {
         List<ReplyCommentEntity> replies = replyCommentRepository.findByCommentIdAndNotDeleted(commentId);
 
         return replies.stream()
                 .map(reply -> {
                     boolean isDeleted = reply.getDeletedAt() != null;
                     return new CommentResponseDTO(
-                            reply.getCommentId(),
-                            reply.getUserId(),
+                            reply.getCommentId().toString(),
+                            reply.getUserId().toString(),
                             reply.getContent(),
                             List.of(), //대댓글은 대댓글이 없음
                             likeService.getLikeCount(LikeType.valueOf("REPLY"), reply.getCommentId()), // 대댓글 좋아요 수

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -2,7 +2,7 @@ package inu.codin.codin.domain.post.domain.reply.service;
 
 import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.common.security.util.SecurityUtils;
-import inu.codin.codin.domain.post.domain.comment.dto.CommentResponseDTO;
+import inu.codin.codin.domain.post.domain.comment.dto.response.CommentResponseDTO;
 import inu.codin.codin.domain.post.domain.comment.entity.CommentEntity;
 import inu.codin.codin.domain.post.domain.comment.repository.CommentRepository;
 import inu.codin.codin.domain.post.domain.like.entity.LikeType;
@@ -83,7 +83,7 @@ public class ReplyCommentService {
                 .map(reply -> {
                     boolean isDeleted = reply.getDeletedAt() != null;
                     return new CommentResponseDTO(
-                            reply.getCommentId().toString(),
+                            reply.get_id().toString(),
                             reply.getUserId().toString(),
                             reply.getContent(),
                             List.of(), //대댓글은 대댓글이 없음

--- a/src/main/java/inu/codin/codin/domain/post/domain/scrap/entity/ScrapEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/scrap/entity/ScrapEntity.java
@@ -3,6 +3,7 @@ package inu.codin.codin.domain.post.domain.scrap.entity;
 import inu.codin.codin.common.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -10,12 +11,12 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Getter
 public class ScrapEntity extends BaseTimeEntity {
     @Id
-    private String id;
-    private String postId;
-    private String userId;
+    private ObjectId _id;
+    private ObjectId postId;
+    private ObjectId userId;
 
     @Builder
-    public ScrapEntity(String postId, String userId) {
+    public ScrapEntity(ObjectId postId, ObjectId userId) {
         this.postId = postId;
         this.userId = userId;
     }

--- a/src/main/java/inu/codin/codin/domain/post/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/scrap/repository/ScrapRepository.java
@@ -1,19 +1,20 @@
 package inu.codin.codin.domain.post.domain.scrap.repository;
 
 import inu.codin.codin.domain.post.domain.scrap.entity.ScrapEntity;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface ScrapRepository extends MongoRepository<ScrapEntity, String> {
+public interface ScrapRepository extends MongoRepository<ScrapEntity, ObjectId> {
 
-    List<ScrapEntity> findByPostId(String postId);
+    List<ScrapEntity> findByPostId(ObjectId postId);
 
-    long countByPostId(String postId);
+    long countByPostId(ObjectId postId);
 
-    void deleteByPostIdAndUserId(String postId, String userId);
+    void deleteByPostIdAndUserId(ObjectId postId, ObjectId userId);
 
-    boolean existsByPostIdAndUserId(String postId, String userId);
+    boolean existsByPostIdAndUserId(ObjectId postId, ObjectId userId);
 }

--- a/src/main/java/inu/codin/codin/domain/post/domain/scrap/service/ScrapService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/scrap/service/ScrapService.java
@@ -12,6 +12,7 @@ import inu.codin.codin.infra.redis.RedisHealthChecker;
 import inu.codin.codin.infra.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,11 +25,12 @@ public class ScrapService {
     private final RedisService redisService;
     private final RedisHealthChecker redisHealthChecker;
 
-    public void addScrap(String postId) {
+    public void addScrap(String id) {
+        ObjectId postId = new ObjectId(id);
         postRepository.findByIdAndNotDeleted(postId)
                 .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."));
 
-        String userId = SecurityUtils.getCurrentUserId();
+        ObjectId userId = SecurityUtils.getCurrentUserId();
 
         if (scrapRepository.existsByPostIdAndUserId(postId, userId)) {
             throw new ScrapCreateFailException("이미 스크랩 한 상태 입니다.");
@@ -44,11 +46,12 @@ public class ScrapService {
         scrapRepository.save(scrap);
     }
 
-    public void removeScrap(String postId) {
+    public void removeScrap(String id) {
+        ObjectId postId = new ObjectId(id);
         postRepository.findByIdAndNotDeleted(postId)
                 .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."));
 
-        String userId = SecurityUtils.getCurrentUserId();
+        ObjectId userId = SecurityUtils.getCurrentUserId();
         if (!scrapRepository.existsByPostIdAndUserId(postId, userId)) {
             throw new ScrapRemoveFailException("스크랩한 적이 없는 게시물입니다.");
         }
@@ -59,7 +62,7 @@ public class ScrapService {
         scrapRepository.deleteByPostIdAndUserId(postId, userId);
     }
 
-    public int getScrapCount(String postId) {
+    public int getScrapCount(ObjectId postId) {
         if (redisHealthChecker.isRedisAvailable()) {
             return redisService.getScrapCount(postId);
         }

--- a/src/main/java/inu/codin/codin/domain/post/dto/request/PostAnonymousUpdateRequestDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/request/PostAnonymousUpdateRequestDTO.java
@@ -2,9 +2,9 @@ package inu.codin.codin.domain.post.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class PostAnonymousUpdateRequestDTO {
     @Schema(description = "익명 여부", example = "true")
     @NotNull

--- a/src/main/java/inu/codin/codin/domain/post/dto/request/PostContentUpdateRequestDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/request/PostContentUpdateRequestDTO.java
@@ -2,9 +2,9 @@ package inu.codin.codin.domain.post.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class PostContentUpdateRequestDTO {
     @Schema(description = "게시물 내용", example = "Updated content")
     @NotBlank

--- a/src/main/java/inu/codin/codin/domain/post/dto/request/PostCreateRequestDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/request/PostCreateRequestDTO.java
@@ -4,14 +4,10 @@ import inu.codin.codin.domain.post.entity.PostCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class PostCreateRequestDTO {
-
-//    @Schema(description = "유저 ID", example = "111111")
-//    @NotBlank
-//    private String userId;
 
     @Schema(description = "게시물 제목", example = "Example")
     @NotBlank

--- a/src/main/java/inu/codin/codin/domain/post/dto/request/PostStatusUpdateRequestDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/request/PostStatusUpdateRequestDTO.java
@@ -3,9 +3,9 @@ package inu.codin.codin.domain.post.dto.request;
 import inu.codin.codin.domain.post.entity.PostStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class PostStatusUpdateRequestDTO {
     @Schema(description = "게시물 상태", example = "ACTIVE")
     @NotNull

--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostDetailResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostDetailResponseDTO.java
@@ -6,51 +6,48 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.Setter;
-import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
 public class PostDetailResponseDTO {
     @Schema(description = "게시물 ID", example = "111111")
     @NotBlank
-    private String _id;
+    private final String _id;
 
     @Schema(description = "유저 ID", example = "111111")
     @NotBlank
-    private String userId;
+    private final String userId;
 
     @Schema(description = "게시물 종류", example = "구해요")
     @NotBlank
-    private PostCategory postCategory;
+    private final PostCategory postCategory;
 
     @Schema(description = "게시물 제목", example = "Example")
     @NotBlank
-    private String title;
+    private final String title;
 
     @Schema(description = "게시물 내용", example = "example content")
     @NotBlank
-    private String content;
+    private final String content;
 
     @Schema(description = "게시물 내 이미지 url , blank 가능", example = "example/1231")
-    private List<String> postImageUrl;
+    private final List<String> postImageUrl;
 
     @Schema(description = "게시물 익명 여부 default = 0 (익명)", example = "0")
     @NotNull
-    private boolean isAnonymous;
+    private final boolean isAnonymous;
 
     @Schema(description = "좋아요 count", example = "0")
-    private int likeCount;
+    private final int likeCount;
 
     @Schema(description = "스크랩 count", example = "0")
-    private int scrapCount;
+    private final int scrapCount;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     @Schema(description = "생성 일자", example = "2024-12-02 20:10:18")
-    private LocalDateTime createdAt;
+    private final LocalDateTime createdAt;
 
     public PostDetailResponseDTO(String userId, String _id, String content, String title, PostCategory postCategory, List<String> postImageUrls , boolean isAnonymous, int likeCount, int scrapCount, LocalDateTime createdAt) {
         this.userId = userId;

--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostDetailResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostDetailResponseDTO.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,13 +15,13 @@ import java.util.List;
 @Getter
 @Setter
 public class PostDetailResponseDTO {
+    @Schema(description = "게시물 ID", example = "111111")
+    @NotBlank
+    private String _id;
+
     @Schema(description = "유저 ID", example = "111111")
     @NotBlank
     private String userId;
-
-    @Schema(description = "게시물 ID", example = "111111")
-    @NotBlank
-    private String postId;
 
     @Schema(description = "게시물 종류", example = "구해요")
     @NotBlank
@@ -51,9 +52,9 @@ public class PostDetailResponseDTO {
     @Schema(description = "생성 일자", example = "2024-12-02 20:10:18")
     private LocalDateTime createdAt;
 
-    public PostDetailResponseDTO(String userId, String postId, String content, String title, PostCategory postCategory, List<String> postImageUrls , boolean isAnonymous, int likeCount, int scrapCount, LocalDateTime createdAt) {
+    public PostDetailResponseDTO(String userId, String _id, String content, String title, PostCategory postCategory, List<String> postImageUrls , boolean isAnonymous, int likeCount, int scrapCount, LocalDateTime createdAt) {
         this.userId = userId;
-        this.postId = postId;
+        this._id = _id;
         this.content = content;
         this.title = title;
         this.postCategory = postCategory;

--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostListResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostListResponseDto.java
@@ -3,18 +3,15 @@ package inu.codin.codin.domain.post.dto.response;
 import inu.codin.codin.domain.post.entity.PostCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
-import lombok.Setter;
-import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
 public class PostListResponseDto extends PostDetailResponseDTO{
 
     @Schema(description = "댓글 및 대댓글 count", example = "0")
-    private int commentCount;
+    private final int commentCount;
 
     public PostListResponseDto(String userId, String postId, String content, String title, PostCategory postCategory, List<String> postImageUrls , boolean isAnonymous, int commentCount, int likeCount, int scrapCount, LocalDateTime createdAt) {
         super(userId, postId, content, title, postCategory, postImageUrls, isAnonymous, likeCount, scrapCount, createdAt);

--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostListResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostListResponseDto.java
@@ -4,6 +4,7 @@ import inu.codin.codin.domain.post.entity.PostCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
+import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/inu/codin/codin/domain/post/entity/PostEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/entity/PostEntity.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -16,9 +17,9 @@ import java.util.List;
 @Getter
 public class PostEntity extends BaseTimeEntity {
     @Id @NotBlank
-    private String postId;
+    private ObjectId _id;
 
-    private String userId; // User 엔티티와의 관계를 유지하기 위한 필드
+    private ObjectId userId; // User 엔티티와의 관계를 유지하기 위한 필드
     private String title;
     private String content;
     private List<String> postImageUrls = new ArrayList<>();
@@ -32,8 +33,8 @@ public class PostEntity extends BaseTimeEntity {
     private int scrapCount = 0; // 스크랩 카운트 (redis)
 
     @Builder
-    public PostEntity(String postId, String userId, PostCategory postCategory, String title, String content, List<String> postImageUrls ,boolean isAnonymous, PostStatus postStatus, int commentCount, int likeCount, int scrapCount) {
-        this.postId = postId;
+    public PostEntity(ObjectId _id, ObjectId userId, PostCategory postCategory, String title, String content, List<String> postImageUrls ,boolean isAnonymous, PostStatus postStatus, int commentCount, int likeCount, int scrapCount) {
+        this._id = _id;
         this.userId = userId;
         this.title = title;
         this.content = content;

--- a/src/main/java/inu/codin/codin/domain/post/repository/PostRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/repository/PostRepository.java
@@ -2,6 +2,7 @@ package inu.codin.codin.domain.post.repository;
 
 import inu.codin.codin.domain.post.entity.PostCategory;
 import inu.codin.codin.domain.post.entity.PostEntity;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,13 +11,13 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostRepository extends MongoRepository<PostEntity, String> {
+public interface PostRepository extends MongoRepository<PostEntity, ObjectId> {
 
     @Query("{'_id':  ?0, 'deletedAt': null, 'postStatus':  { $in:  ['ACTIVE'] }}")
-    Optional<PostEntity> findByIdAndNotDeleted(String Id);
+    Optional<PostEntity> findByIdAndNotDeleted(ObjectId Id);
 
     @Query("{'userId': ?0, 'deletedAt': null, 'postStatus':  { $in:  ['ACTIVE'] }}")
-    List<PostEntity> findByUserIdAndNotDeleted(String userId);
+    List<PostEntity> findByUserIdAndNotDeleted(ObjectId userId);
 
     @Query("{'deletedAt': null, 'postStatus':  { $in:  ['ACTIVE'] }, 'postCategory': ?0 }")
     List<PostEntity> findAllAndNotDeletedAndActive(PostCategory postCategory);

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -21,6 +21,7 @@ import inu.codin.codin.domain.user.entity.UserRole;
 import inu.codin.codin.infra.s3.S3Service;
 import inu.codin.codin.infra.s3.exception.ImageRemoveException;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -47,7 +48,7 @@ public class PostService {
 
     public void createPost(PostCreateRequestDTO postCreateRequestDTO, List<MultipartFile> postImages) {
         List<String> imageUrls = handleImageUpload(postImages);
-        String userId = SecurityUtils.getCurrentUserId();
+        ObjectId userId = SecurityUtils.getCurrentUserId();
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
                 postCreateRequestDTO.getPostCategory().toString().split("_")[0].equals("EXTRACURRICULAR")){
@@ -71,7 +72,7 @@ public class PostService {
 
     public void updatePostContent(String postId, PostContentUpdateRequestDTO requestDTO, List<MultipartFile> postImages) {
 
-        PostEntity post = postRepository.findByIdAndNotDeleted(postId)
+        PostEntity post = postRepository.findByIdAndNotDeleted(new ObjectId(postId))
                 .orElseThrow(()->new NotFoundException("해당 게시물 없음"));
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
@@ -86,7 +87,7 @@ public class PostService {
     }
 
     public void updatePostAnonymous(String postId, PostAnonymousUpdateRequestDTO requestDTO) {
-        PostEntity post = postRepository.findByIdAndNotDeleted(postId)
+        PostEntity post = postRepository.findByIdAndNotDeleted(new ObjectId(postId))
                 .orElseThrow(()->new NotFoundException("해당 게시물 없음"));
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
@@ -99,7 +100,7 @@ public class PostService {
     }
 
     public void updatePostStatus(String postId, PostStatusUpdateRequestDTO requestDTO) {
-        PostEntity post = postRepository.findByIdAndNotDeleted(postId)
+        PostEntity post = postRepository.findByIdAndNotDeleted(new ObjectId(postId))
                 .orElseThrow(()->new NotFoundException("해당 게시물 없음"));
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
@@ -121,7 +122,7 @@ public class PostService {
 
     //해당 유저가 작성한 모든 글 반환 :: 게시글 내용 + 댓글+대댓글의 수 + 좋아요,스크랩 count 수 반환
     public List<PostListResponseDto> getAllUserPosts() {
-        String userId = SecurityUtils.getCurrentUserId();
+        ObjectId userId = SecurityUtils.getCurrentUserId();
         List<PostEntity> posts = postRepository.findByUserIdAndNotDeleted(userId);
         return getPostListResponseDtos(posts);
     }
@@ -130,16 +131,16 @@ public class PostService {
         return posts.stream()
                 .sorted(Comparator.comparing(PostEntity::getCreatedAt).reversed())
                 .map(post -> new PostListResponseDto(
-                        post.getUserId(),
-                        post.getPostId(),
+                        post.getUserId().toString(),
+                        post.get_id().toString(),
                         post.getContent(),
                         post.getTitle(),
                         post.getPostCategory(),
                         post.getPostImageUrls(),
                         post.isAnonymous(),
                         post.getCommentCount(),
-                        likeService.getLikeCount(LikeType.valueOf("POST"),post.getPostId()),       // 좋아요 수
-                        scrapService.getScrapCount(post.getPostId()),      // 스크랩 수
+                        likeService.getLikeCount(LikeType.valueOf("POST"),post.get_id()),       // 좋아요 수
+                        scrapService.getScrapCount(post.get_id()),      // 스크랩 수
                         post.getCreatedAt()
                 ))
                 .toList();
@@ -147,19 +148,19 @@ public class PostService {
 
     //게시물 상세 조회 :: 게시글 (내용 + 좋아요,스크랩 count 수)  + 댓글 +대댓글 (내용 +좋아요,스크랩 count 수 ) 반환
     public PostDetailResponseDTO getPostWithDetail(String postId) {
-        PostEntity post = postRepository.findByIdAndNotDeleted(postId)
+        PostEntity post = postRepository.findByIdAndNotDeleted(new ObjectId(postId))
                 .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
 
         return new PostDetailResponseDTO(
-                post.getUserId(),
-                post.getPostId(),
+                post.getUserId().toString(),
+                post.get_id().toString(),
                 post.getContent(),
                 post.getTitle(),
                 post.getPostCategory(),
                 post.getPostImageUrls(),
                 post.isAnonymous(),
-                likeService.getLikeCount(LikeType.valueOf("POST"),post.getPostId()),   // 좋아요 수
-                scrapService.getScrapCount(post.getPostId()),   // 스크랩 수
+                likeService.getLikeCount(LikeType.valueOf("POST"),post.get_id()),   // 좋아요 수
+                scrapService.getScrapCount(post.get_id()),   // 스크랩 수
                 post.getCreatedAt()
         );
     }
@@ -167,7 +168,7 @@ public class PostService {
 
 
     public void softDeletePost(String postId) {
-        PostEntity post = postRepository.findByIdAndNotDeleted(postId)
+        PostEntity post = postRepository.findByIdAndNotDeleted(new ObjectId(postId))
                 .orElseThrow(()-> new NotFoundException("게시물을 찾을 수 없음."));
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
@@ -182,7 +183,7 @@ public class PostService {
 
     public void deletePostImage(String postId, String imageUrl) {
 
-        PostEntity post = postRepository.findByIdAndNotDeleted(postId)
+        PostEntity post = postRepository.findByIdAndNotDeleted(new ObjectId(postId))
                 .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -114,32 +115,20 @@ public class PostService {
     // 모든 글 반환 ::  게시글 내용 + 댓글+대댓글의 수 + 좋아요,스크랩 count 수 반환
     public List<PostListResponseDto> getAllPosts(PostCategory postCategory) {
         List<PostEntity> posts = postRepository.findAllAndNotDeletedAndActive(postCategory);
-
-        return posts.stream()
-                .map(post -> new PostListResponseDto(
-                        post.getUserId(),
-                        post.getPostId(),
-                        post.getContent(),
-                        post.getTitle(),
-                        post.getPostCategory(),
-                        post.getPostImageUrls(),
-                        post.isAnonymous(),
-                        post.getCommentCount(), // 댓글 수
-                        likeService.getLikeCount(LikeType.valueOf("POST"),post.getPostId()),       // 좋아요 수
-                        scrapService.getScrapCount(post.getPostId()),       // 스크랩 수
-                        post.getCreatedAt()
-                )).toList();
+        return getPostListResponseDtos(posts);
     }
 
 
     //해당 유저가 작성한 모든 글 반환 :: 게시글 내용 + 댓글+대댓글의 수 + 좋아요,스크랩 count 수 반환
     public List<PostListResponseDto> getAllUserPosts() {
-
         String userId = SecurityUtils.getCurrentUserId();
-
         List<PostEntity> posts = postRepository.findByUserIdAndNotDeleted(userId);
+        return getPostListResponseDtos(posts);
+    }
 
+    private List<PostListResponseDto> getPostListResponseDtos(List<PostEntity> posts) {
         return posts.stream()
+                .sorted(Comparator.comparing(PostEntity::getCreatedAt).reversed())
                 .map(post -> new PostListResponseDto(
                         post.getUserId(),
                         post.getPostId(),

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -50,7 +50,7 @@ public class PostService {
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
                 postCreateRequestDTO.getPostCategory().toString().split("_")[0].equals("EXTRACURRICULAR")){
-            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "게시물을 업로드 할 권한이 없습니다.");
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "비교과 게시글에 대한 권한이 없습니다.");
         }
 
         PostEntity postEntity = PostEntity.builder()
@@ -75,7 +75,7 @@ public class PostService {
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
                 post.getPostCategory().toString().split("_")[0].equals("EXTRACURRICULAR")){
-            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "게시물을 업로드 할 권한이 없습니다.");
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "비교과 게시글에 대한 권한이 없습니다.");
         }
 
         List<String> imageUrls = handleImageUpload(postImages);
@@ -90,7 +90,7 @@ public class PostService {
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
                 post.getPostCategory().toString().split("_")[0].equals("EXTRACURRICULAR")){
-            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "게시물을 업로드 할 권한이 없습니다.");
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "비교과 게시글에 대한 권한이 없습니다.");
         }
 
         post.updatePostAnonymous(requestDTO.isAnonymous());
@@ -103,7 +103,7 @@ public class PostService {
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
                 post.getPostCategory().toString().split("_")[0].equals("EXTRACURRICULAR")){
-            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "게시물을 업로드 할 권한이 없습니다.");
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "비교과 게시글에 대한 권한이 없습니다.");
         }
 
         post.updatePostStatus(requestDTO.getPostStatus());
@@ -183,7 +183,7 @@ public class PostService {
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
                 post.getPostCategory().toString().split("_")[0].equals("EXTRACURRICULAR")){
-            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "게시물을 업로드 할 권한이 없습니다.");
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "비교과 게시글에 대한 권한이 없습니다.");
         }
 
         post.delete();
@@ -198,7 +198,7 @@ public class PostService {
 
         if (SecurityUtils.getCurrentUserRole().equals(UserRole.USER) &&
                 post.getPostCategory().toString().split("_")[0].equals("EXTRACURRICULAR"))
-            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "게시물을 업로드 할 권한이 없습니다.");
+            throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "비교과 게시글에 대한 권한이 없습니다.");
 
 
         if (!post.getPostImageUrls().contains(imageUrl))

--- a/src/main/java/inu/codin/codin/domain/user/dto/UserCreateRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/user/dto/UserCreateRequestDto.java
@@ -3,10 +3,8 @@ package inu.codin.codin.domain.user.dto;
 import inu.codin.codin.common.Department;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Data;
 import lombok.Getter;
 
-@Data
 @Getter
 public class UserCreateRequestDto {
 

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -5,6 +5,7 @@ import inu.codin.codin.common.Department;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -13,7 +14,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class UserEntity extends BaseTimeEntity {
 
     @Id @NotBlank
-    private String id;
+    private ObjectId _id;
 
     private String email;
 

--- a/src/main/java/inu/codin/codin/domain/user/repository/UserRepository.java
+++ b/src/main/java/inu/codin/codin/domain/user/repository/UserRepository.java
@@ -1,13 +1,14 @@
 package inu.codin.codin.domain.user.repository;
 
 import inu.codin.codin.domain.user.entity.UserEntity;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends MongoRepository<UserEntity, String> {
+public interface UserRepository extends MongoRepository<UserEntity, ObjectId> {
 
     Optional<UserEntity> findByEmail(String email);
     Optional<UserEntity> findByStudentId(String studentId);

--- a/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetails.java
+++ b/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetails.java
@@ -6,6 +6,7 @@ import inu.codin.codin.domain.user.entity.UserRole;
 import inu.codin.codin.domain.user.entity.UserStatus;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.types.ObjectId;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,7 +17,7 @@ import java.util.Collections;
 @Getter
 public class CustomUserDetails implements UserDetails {
 
-    private final String id;
+    private final ObjectId id;
     private final String email;
     private final String password;
     private final String studentId;
@@ -30,7 +31,7 @@ public class CustomUserDetails implements UserDetails {
     private final Collection<? extends GrantedAuthority> authorities;
 
     @Builder
-    public CustomUserDetails(String id, String email, String password, String studentId, String name, String nickname, String profileImageUrl, Department department, UserRole role, UserStatus status, Collection<? extends GrantedAuthority> authorities) {
+    public CustomUserDetails(ObjectId id, String email, String password, String studentId, String name, String nickname, String profileImageUrl, Department department, UserRole role, UserStatus status, Collection<? extends GrantedAuthority> authorities) {
         this.id = id;
         this.email = email;
         this.password = password;
@@ -46,7 +47,7 @@ public class CustomUserDetails implements UserDetails {
 
     public static CustomUserDetails from(UserEntity userEntity) {
         return CustomUserDetails.builder()
-                .id(userEntity.getId())
+                .id(userEntity.get_id())
                 .email(userEntity.getEmail())
                 .password(userEntity.getPassword())
                 .studentId(userEntity.getStudentId())

--- a/src/main/java/inu/codin/codin/infra/redis/RedisService.java
+++ b/src/main/java/inu/codin/codin/infra/redis/RedisService.java
@@ -4,6 +4,7 @@ package inu.codin.codin.infra.redis;
 import inu.codin.codin.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -38,17 +39,17 @@ public class RedisService {
         }
     }
 
-    public void addLike(String entityType, String entityId, String userId) {
+    public void addLike(String entityType, ObjectId entityId, ObjectId userId) {
         String redisKey = entityType + ":likes:" + entityId;
-        redisTemplate.opsForSet().add(redisKey, userId);
+        redisTemplate.opsForSet().add(redisKey, String.valueOf(userId));
     }
 
-    public void removeLike(String entityType, String entityId, String userId) {
+    public void removeLike(String entityType, ObjectId entityId, ObjectId userId) {
         String redisKey = entityType + ":likes:" + entityId;
-        redisTemplate.opsForSet().remove(redisKey, userId);
+        redisTemplate.opsForSet().remove(redisKey, String.valueOf(userId));
     }
 
-    public int getLikeCount(String entityType, String entityId) {
+    public int getLikeCount(String entityType, ObjectId entityId) {
         String redisKey = entityType + ":likes:" + entityId;
         Long count = redisTemplate.opsForSet().size(redisKey);
         return count != null ? count.intValue() : 0;
@@ -59,18 +60,18 @@ public class RedisService {
         return redisTemplate.opsForSet().members(redisKey);
     }
 
-    public void addScrap(String postId, String userId) {
-        String redisKey = "post:scraps:" + postId;
-        redisTemplate.opsForSet().add(redisKey, userId);
+    public void addScrap(ObjectId postId, ObjectId userId) {
+        String redisKey = "post:scraps:" + postId.toString();
+        redisTemplate.opsForSet().add(redisKey, userId.toString());
     }
 
-    public void removeScrap(String postId, String userId) {
-        String redisKey = "post:scraps:" + postId;
-        redisTemplate.opsForSet().remove(redisKey, userId);
+    public void removeScrap(ObjectId postId, ObjectId userId) {
+        String redisKey = "post:scraps:" + postId.toString();
+        redisTemplate.opsForSet().remove(redisKey, userId.toString());
     }
 
-    public int getScrapCount(String postId) {
-        String redisKey = "post:scraps:" + postId;
+    public int getScrapCount(ObjectId postId) {
+        String redisKey = "post:scraps:" + postId.toString();
         Long scrapCount = redisTemplate.opsForSet().size(redisKey);
         return scrapCount != null ? scrapCount.intValue() : 0;
     }

--- a/src/main/java/inu/codin/codin/infra/redis/SyncScheduler.java
+++ b/src/main/java/inu/codin/codin/infra/redis/SyncScheduler.java
@@ -14,6 +14,7 @@ import inu.codin.codin.domain.post.domain.scrap.entity.ScrapEntity;
 import inu.codin.codin.domain.post.domain.scrap.repository.ScrapRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -49,7 +50,7 @@ public class SyncScheduler {
         log.info(" 동기화 작업 완료");
     }
 
-    private <T> void syncEntityLikes(String entityType, MongoRepository<T, String> repository) {
+    private <T> void syncEntityLikes(String entityType, MongoRepository<T, ObjectId> repository) {
         Set<String> redisKeys = redisService.getKeys(entityType+ ":likes:*");
         if (redisKeys == null || redisKeys.isEmpty()) {
             return;
@@ -59,23 +60,25 @@ public class SyncScheduler {
         for (String redisKey : redisKeys) {
             String likeTypeId = redisKey.replace(entityType + ":likes:", "");
             Set<String> likedUsers = redisService.getLikedUsers(entityType, likeTypeId);
+            ObjectId likeId = new ObjectId(likeTypeId);
 
             // (좋아요 삭제) MongoDB에서 Redis에 없는 사용자 삭제
-            List<LikeEntity> dbLikes = likeRepository.findByLikeTypeAndLikeTypeId(likeType, likeTypeId);
+            List<LikeEntity> dbLikes = likeRepository.findByLikeTypeAndLikeTypeId(likeType, likeId);
             for (LikeEntity dbLike : dbLikes) {
-                if (!likedUsers.contains(dbLike.getUserId())) {
-                    log.info("MongoDB에서 사용자 삭제: UserID={}, EntityID={}", dbLike.getUserId(), likeTypeId);
+                if (!likedUsers.contains(dbLike.getUserId().toString())) {
+                    log.info("MongoDB에서 사용자 삭제: UserID={}, EntityID={}", dbLike.getUserId(), likeId);
                     likeRepository.delete(dbLike);
                 }
             }
 
             // (좋아요 추가) Redis에는 있지만 MongoDB에 없는 사용자 추가
-            for (String userId : likedUsers) {
-                if (!likeRepository.existsByLikeTypeAndLikeTypeIdAndUserId(likeType, likeTypeId, userId)) {
-                    log.info("MongoDB에 사용자 추가: UserID={}, EntityID={}", userId, likeTypeId);
+            for (String id : likedUsers) {
+                ObjectId userId = new ObjectId(id);
+                if (!likeRepository.existsByLikeTypeAndLikeTypeIdAndUserId(likeType, likeId, userId)) {
+                    log.info("MongoDB에 사용자 추가: UserID={}, EntityID={}", userId, likeId);
                     LikeEntity dbLike = LikeEntity.builder()
                             .likeType(likeType)
-                            .likeTypeId(likeTypeId)
+                            .likeTypeId(likeId)
                             .userId(userId)
                             .build();
                     likeRepository.save(dbLike);
@@ -85,21 +88,21 @@ public class SyncScheduler {
             // (count 업데이트) Redis 사용자 수로 엔티티의 likeCount 업데이트
             int likeCount = likedUsers.size();
             if (repository instanceof PostRepository postRepo) {
-                PostEntity post = postRepo.findByIdAndNotDeleted(likeTypeId).orElse(null);
+                PostEntity post = postRepo.findByIdAndNotDeleted(likeId).orElse(null);
                 if (post != null && post.getLikeCount() != likeCount) {
                     log.info("PostEntity 좋아요 수 업데이트: EntityID={}, Count={}", likeTypeId, likeCount);
                     post.updateLikeCount(likeCount);
                     postRepo.save(post);
                 }
             } else if (repository instanceof CommentRepository commentRepo) {
-                CommentEntity comment = commentRepo.findByIdAndNotDeleted(likeTypeId).orElse(null);
+                CommentEntity comment = commentRepo.findByIdAndNotDeleted(likeId).orElse(null);
                 if (comment != null && comment.getLikeCount() != likeCount) {
                     log.info("CommentEntity 좋아요 수 업데이트: EntityID={}, Count={}", likeTypeId, likeCount);
                     comment.updateLikeCount(likeCount);
                     commentRepo.save(comment);
                 }
             } else if (repository instanceof ReplyCommentRepository replyRepo) {
-                ReplyCommentEntity reply = replyRepo.findByIdAndNotDeleted(likeTypeId).orElse(null);
+                ReplyCommentEntity reply = replyRepo.findByIdAndNotDeleted(likeId).orElse(null);
                 if (reply != null && reply.getLikeCount() != likeCount) {
                     log.info("ReplyEntity 좋아요 수 업데이트: EntityID={}, Count={}", likeTypeId, likeCount);
                     reply.updateLikeCount(likeCount);
@@ -119,17 +122,19 @@ public class SyncScheduler {
         for (String redisKey : redisKeys) {
             String postId = redisKey.replace("post:scraps:", "");
             Set<String> redisScrappedUsers = redisService.getLikedUsers("post", postId);
+            ObjectId id = new ObjectId(postId);
 
             // MongoDB의 스크랩 데이터 가져오기
-            List<ScrapEntity> dbScraps = scrapRepository.findByPostId(postId);
+            List<ScrapEntity> dbScraps = scrapRepository.findByPostId(id);
             Set<String> dbScrappedUsers = dbScraps.stream()
                     .map(ScrapEntity::getUserId)
+                    .map(ObjectId::toString)
                     .collect(Collectors.toSet());
 
             // (스크랩 삭제) MongoDB에 있지만 Redis에 없는 사용자 삭제
             for (ScrapEntity dbScrap : dbScraps) {
-                if (!redisScrappedUsers.contains(dbScrap.getUserId())) {
-                    log.info("MongoDB에서 사용자 삭제: UserID={}, PostID={}", dbScrap.getUserId(), postId);
+                if (!redisScrappedUsers.contains(dbScrap.getUserId().toString())) {
+                    log.info("MongoDB에서 사용자 삭제: UserID={}, PostID={}", dbScrap.getUserId(), id);
                     scrapRepository.delete(dbScrap);
                 }
             }
@@ -137,10 +142,10 @@ public class SyncScheduler {
             // (스크랩 추가) Redis에 있지만 MongoDB에 없는 사용자 추가
             for (String redisUser : redisScrappedUsers) {
                 if (!dbScrappedUsers.contains(redisUser)) {
-                    log.info("MongoDB에 사용자 추가: UserID={}, PostID={}", redisUser, postId);
+                    log.info("MongoDB에 사용자 추가: UserID={}, PostID={}", redisUser, id);
                     ScrapEntity dbScrap = ScrapEntity.builder()
-                            .postId(postId)
-                            .userId(redisUser)
+                            .postId(id)
+                            .userId(new ObjectId(redisUser))
                             .build();
                     scrapRepository.save(dbScrap);
                 }
@@ -148,10 +153,10 @@ public class SyncScheduler {
 
             // Redis 사용자 수로 PostEntity의 scrapCount 업데이트
             int redisScrapCount = redisScrappedUsers.size();
-            PostEntity post = postRepository.findByIdAndNotDeleted(postId)
+            PostEntity post = postRepository.findByIdAndNotDeleted(id)
                     .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
             if (post.getScrapCount() != redisScrapCount) {
-                log.info("PostEntity 스크랩 수 업데이트: PostID={}, Count={}", postId, redisScrapCount);
+                log.info("PostEntity 스크랩 수 업데이트: PostID={}, Count={}", id, redisScrapCount);
                 post.updateScrapCount(redisScrapCount);
                 postRepository.save(post);
             }

--- a/src/main/java/inu/codin/codin/infra/redis/SyncScheduler.java
+++ b/src/main/java/inu/codin/codin/infra/redis/SyncScheduler.java
@@ -66,7 +66,7 @@ public class SyncScheduler {
             List<LikeEntity> dbLikes = likeRepository.findByLikeTypeAndLikeTypeId(likeType, likeId);
             for (LikeEntity dbLike : dbLikes) {
                 if (!likedUsers.contains(dbLike.getUserId().toString())) {
-                    log.info("MongoDB에서 사용자 삭제: UserID={}, EntityID={}", dbLike.getUserId(), likeId);
+                    log.info("[MongoDB] 좋아요 삭제: UserID={}, EntityID={}", dbLike.getUserId(), likeId);
                     likeRepository.delete(dbLike);
                 }
             }
@@ -75,7 +75,7 @@ public class SyncScheduler {
             for (String id : likedUsers) {
                 ObjectId userId = new ObjectId(id);
                 if (!likeRepository.existsByLikeTypeAndLikeTypeIdAndUserId(likeType, likeId, userId)) {
-                    log.info("MongoDB에 사용자 추가: UserID={}, EntityID={}", userId, likeId);
+                    log.info("[MongoDB] 좋아요 추가: UserID={}, EntityID={}", userId, likeId);
                     LikeEntity dbLike = LikeEntity.builder()
                             .likeType(likeType)
                             .likeTypeId(likeId)
@@ -134,7 +134,7 @@ public class SyncScheduler {
             // (스크랩 삭제) MongoDB에 있지만 Redis에 없는 사용자 삭제
             for (ScrapEntity dbScrap : dbScraps) {
                 if (!redisScrappedUsers.contains(dbScrap.getUserId().toString())) {
-                    log.info("MongoDB에서 사용자 삭제: UserID={}, PostID={}", dbScrap.getUserId(), id);
+                    log.info("[MongoDB] 스크랩 삭제: UserID={}, PostID={}", dbScrap.getUserId(), id);
                     scrapRepository.delete(dbScrap);
                 }
             }
@@ -142,7 +142,7 @@ public class SyncScheduler {
             // (스크랩 추가) Redis에 있지만 MongoDB에 없는 사용자 추가
             for (String redisUser : redisScrappedUsers) {
                 if (!dbScrappedUsers.contains(redisUser)) {
-                    log.info("MongoDB에 사용자 추가: UserID={}, PostID={}", redisUser, id);
+                    log.info("[MongoDB] 스크랩 추가: UserID={}, PostID={}", redisUser, id);
                     ScrapEntity dbScrap = ScrapEntity.builder()
                             .postId(id)
                             .userId(new ObjectId(redisUser))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#SC-91

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**refactor**
1. 비교과 게시글에 대하여 MANAGER,ADMIN의 권한만 허용
2. 모든 Exception이 404로 반환하고 있기 때문에, JWT 관련 Exception은 403, 401로 반환하도록 설정
3. DTO 어노테이션 Getter로 충분하기에 통합, ResponseDto의 경우 변수에 final 처리를 통해 값의 불변함 적용
4. pk 값인 _id를 String에서 ObjectId로 변경
-> 서비스 상에서는  ObjectId로 구분하지만 client에 반환은 String 값으로 처리 (꼭 확인)
-> redis 상에서 다룰 때도 String으로 처리
5. API 마다 유저 검증에 대한 validate 함수 적용 예정
-> ex ) 게시글을 수정할 때, 현재 로그인한 유저 == 게시글을 작성한 유저에  대한 검증
하지만 이는 추후 JWT 방식이 적용되면 사용할 예정, 현재는 token 값이 계속 null로 잡히기 때문에 해당 함수를 사용할 수 없음.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
