### PR TITLE
[SC-100] feat : 검색 엔진 기능 추가

### DIFF
--- a/src/main/java/inu/codin/codin/domain/post/controller/PostController.java
+++ b/src/main/java/inu/codin/codin/domain/post/controller/PostController.java
@@ -12,9 +12,12 @@ import inu.codin.codin.domain.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,6 +25,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/posts")
+@Validated
 @Tag(name = "POST API", description = "게시글 API")
 public class PostController {
 
@@ -91,7 +95,7 @@ public class PostController {
     )
     @GetMapping("/category")
     public ResponseEntity<SingleResponse<PostPageResponse>> getAllPosts(@RequestParam PostCategory postCategory,
-                                                                        @RequestParam("page") int pageNumber) {
+                                                                        @RequestParam("page") @NotNull int pageNumber) {
         PostPageResponse postpages= postService.getAllPosts(postCategory, pageNumber);
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(200, "카테고리별 삭제 되지 않은 모든 게시물 조회 성공", postpages));
@@ -122,5 +126,15 @@ public class PostController {
         postService.softDeletePost(postId);
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(200, "게시물이 삭제되었습니다.", null));
+    }
+
+    @Operation(
+            summary = "검색 엔진"
+    )
+    @GetMapping("/search")
+    public ResponseEntity<SingleResponse<?>> searchPosts(@RequestParam("keyword") @Size(min = 2) String keyword,
+                                                         @RequestParam("pageNumber") @NotNull int pageNumber){
+        return ResponseEntity.ok()
+                .body(new SingleResponse<>(200, "'"+keyword+"'"+"으로 검색된 게시글 반환 완료", postService.searchPosts(keyword, pageNumber)));
     }
 }

--- a/src/main/java/inu/codin/codin/domain/post/repository/PostRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/repository/PostRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -24,4 +23,7 @@ public interface PostRepository extends MongoRepository<PostEntity, ObjectId> {
     Page<PostEntity> findAllByUserIdOrderByCreatedAt(ObjectId userId, PageRequest pageRequest);
 
     Page<PostEntity> findByPostCategoryStartingWithOrderByCreatedAt(String prefix, PageRequest pageRequest);
+
+    @Query("{ '$or': [ { 'content': { $regex: ?0, $options: 'i' } }, { 'title': { $regex: ?0, $options: 'i' } } ] }")
+    Page<PostEntity> findAllByKeyword(String keyword, PageRequest pageRequest);
 }

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -197,5 +197,10 @@ public class PostService {
                 .build();
     }
 
+    public PostPageResponse searchPosts(String keyword, int pageNumber) {
+        PageRequest pageRequest = PageRequest.of(pageNumber, 20, Sort.by("createdAt").descending());
+        Page<PostEntity> page = postRepository.findAllByKeyword(keyword, pageRequest);
+        return PostPageResponse.of(getPostListResponseDtos(page.getContent()), page.getTotalPages() - 1, page.hasNext() ? page.getPageable().getPageNumber() + 1 : -1);
+    }
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

SC-100

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 게시글 검색 엔진 기능
- keyword(길이 2 이상)가 포함된 제목과 내용의 게시글 반환

- keyword가 2 미만인 경우 -> 유효성 검사 통과 실패
- 구해요, 소통해요, 비교과 게시글 전체에서 검색이 진행됨

### 스크린샷 (선택)

'현장' 이라는 keyword에 비교과 게시글 반환
![image](https://github.com/user-attachments/assets/b74b1f3a-ff37-4884-ab9c-b6787eb40bae)

'현'이라는 2 미만의 keyword를 작성할 경우
![image](https://github.com/user-attachments/assets/85bc29f9-8b5c-4dc0-b001-dd4038d7f22f)

'content'이라는 keyword에 REQUEST_STUDY, REQUEST_PROJECT 모두 반환
![image](https://github.com/user-attachments/assets/0c6cac89-a128-4668-afad-906dd1b0de06)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

에러를 더 잡아야 하는 부분이 있을까 고민이 되는....
