### PR TITLE
refactor : User 이미지 업로드, multipart/form-data 변경

### DIFF
--- a/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
+++ b/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
@@ -12,8 +12,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping(value = "/users")
@@ -24,10 +26,11 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "회원가입")
-    @PostMapping("/signup")
+    @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SingleResponse<?>> signUpUser(
-            @RequestBody @Valid UserCreateRequestDto userCreateRequestDto) {
-        userService.createUser(userCreateRequestDto);
+            @RequestPart @Valid UserCreateRequestDto userCreateRequestDto,
+            @RequestPart(value = "userImage", required = false) MultipartFile userImage) {
+        userService.createUser(userCreateRequestDto, userImage);
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(200, "회원가입 성공", null));
     }

--- a/src/main/java/inu/codin/codin/domain/user/dto/request/UserCreateRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/user/dto/request/UserCreateRequestDto.java
@@ -30,11 +30,6 @@ public class UserCreateRequestDto {
     @NotBlank
     private String nickname;
 
-    //todo 프로필 이미지 업로드 처리 ex) 이미지 크기 제한..
-    @Schema(description = "프로필 이미지 URL", example = "https://avatars.githubusercontent.com/u/77490521?v=4")
-    @NotBlank
-    private String profileImageUrl;
-
     @Schema(description = "소속", example = "IT_COLLEGE")
     private Department department;
 

--- a/src/main/java/inu/codin/codin/domain/user/service/UserService.java
+++ b/src/main/java/inu/codin/codin/domain/user/service/UserService.java
@@ -25,16 +25,17 @@ import inu.codin.codin.domain.user.entity.UserStatus;
 import inu.codin.codin.domain.user.exception.UserCreateFailException;
 import inu.codin.codin.domain.user.exception.UserPasswordChangeFailException;
 import inu.codin.codin.domain.user.repository.UserRepository;
+import inu.codin.codin.infra.s3.S3Service;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.catalina.User;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -49,10 +50,15 @@ public class UserService {
     private final PostRepository postRepository;
     private final ScrapRepository scrapRepository;
     private final CommentRepository commentRepository;
+
     private final PasswordEncoder passwordEncoder;
     private final PostService postService;
+    private final S3Service s3Service;
 
-    public void createUser(UserCreateRequestDto userCreateRequestDto) {
+    public void createUser(UserCreateRequestDto userCreateRequestDto, MultipartFile userImage) {
+
+        String imageUrl = null;
+        if (userImage != null) imageUrl = s3Service.handleImageUpload(List.of(userImage)).get(0);
 
         String encodedPassword = passwordEncoder.encode(userCreateRequestDto.getPassword());
 
@@ -66,7 +72,7 @@ public class UserService {
                 .studentId(userCreateRequestDto.getStudentId())
                 .name(userCreateRequestDto.getName())
                 .nickname(userCreateRequestDto.getNickname())
-                .profileImageUrl(userCreateRequestDto.getProfileImageUrl())
+                .profileImageUrl(imageUrl)
                 .department(userCreateRequestDto.getDepartment())
                 .status(UserStatus.ACTIVE)
                 .role(UserRole.USER)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 유저 회원가입 로직에서 이미지 첨부 부분 분리
- Multipart/form-data 형식으로 처리

### 스크린샷 (선택)

사진을 업로드 하는 경우 url 반환 완료
![image](https://github.com/user-attachments/assets/1c4ae0b3-7540-4586-8a05-2134eca979b3)

첨부하지 않은 경우에도 잘 회원가입이 되고,  null로 반환되는 모습
![image](https://github.com/user-attachments/assets/dd2731ad-bc0a-4647-bb10-d52a1879d2e5)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
