### PR TITLE
SC-102 Top3 Best 게시글 반환

### DIFF
--- a/src/main/java/inu/codin/codin/common/BaseTimeEntity.java
+++ b/src/main/java/inu/codin/codin/common/BaseTimeEntity.java
@@ -28,4 +28,8 @@ public abstract class BaseTimeEntity {
         this.deletedAt = null;
     }
 
+    public void recreatedAt(){
+        this.createdAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/inu/codin/codin/domain/post/controller/PostController.java
+++ b/src/main/java/inu/codin/codin/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package inu.codin.codin.domain.post.controller;
 
+import inu.codin.codin.common.response.ListResponse;
 import inu.codin.codin.common.response.SingleResponse;
 import inu.codin.codin.domain.post.dto.request.PostAnonymousUpdateRequestDTO;
 import inu.codin.codin.domain.post.dto.request.PostContentUpdateRequestDTO;
@@ -122,5 +123,12 @@ public class PostController {
         postService.softDeletePost(postId);
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(200, "게시물이 삭제되었습니다.", null));
+    }
+
+    @Operation(summary = "Top 3 베스트 게시글 가져오기")
+    @GetMapping("/top3")
+    public ResponseEntity<ListResponse<?>> getTop3BestPosts(){
+        return ResponseEntity.ok()
+                .body(new ListResponse<>(200, "Top3 베스트 게시글 반환 완료", postService.getTop3BestPosts()));
     }
 }

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/entity/CommentEntity.java
@@ -1,7 +1,6 @@
 package inu.codin.codin.domain.post.domain.comment.entity;
 
 import inu.codin.codin.common.BaseTimeEntity;
-import inu.codin.codin.domain.post.exception.StateUpdateException;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -16,6 +16,7 @@ import inu.codin.codin.domain.post.domain.comment.repository.CommentRepository;
 import inu.codin.codin.domain.post.domain.reply.repository.ReplyCommentRepository;
 import inu.codin.codin.domain.user.entity.UserEntity;
 import inu.codin.codin.domain.user.repository.UserRepository;
+import inu.codin.codin.infra.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
@@ -37,6 +38,7 @@ public class CommentService {
     private final UserRepository userRepository;
     private final LikeService likeService;
     private final ReplyCommentService replyCommentService;
+    private final RedisService redisService;
 
     // 댓글 추가
     public void addComment(String id, CommentCreateRequestDTO requestDTO) {
@@ -55,6 +57,7 @@ public class CommentService {
 
         // 댓글 수 증가
         post.updateCommentCount(post.getCommentCount() + 1);
+        redisService.applyBestScore(1, postId);
         postRepository.save(post);
         log.info("댓글 추가완료 postId: {}.", postId);
     }

--- a/src/main/java/inu/codin/codin/domain/post/domain/like/repository/LikeRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/like/repository/LikeRepository.java
@@ -4,7 +4,6 @@ import inu.codin.codin.domain.post.domain.like.entity.LikeEntity;
 import inu.codin.codin.domain.post.domain.like.entity.LikeType;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
@@ -15,15 +14,14 @@ import java.util.List;
 
 public interface LikeRepository extends MongoRepository<LikeEntity, ObjectId> {
     // 특정 엔티티(게시글/댓글/대댓글)의 좋아요 개수 조회
-    long countByLikeTypeAndLikeTypeId(LikeType likeType, ObjectId id);
+    long countByLikeTypeAndLikeTypeIdAndDeletedAtIsNull(LikeType likeType, ObjectId id);
 
     // 특정 엔티티의 좋아요 데이터 조회
-    List<LikeEntity> findByLikeTypeAndLikeTypeId(LikeType likeType, ObjectId id);
+    List<LikeEntity> findByLikeTypeAndLikeTypeIdAndDeletedAtIsNull(LikeType likeType, ObjectId id);
 
-    // 특정 사용자의 좋아요 삭제
-    void deleteByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, ObjectId id, ObjectId userId);
+    boolean existsByLikeTypeAndLikeTypeIdAndUserIdAndDeletedAtIsNull(LikeType likeType, ObjectId id, ObjectId userId);
 
-    boolean existsByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, ObjectId id, ObjectId userId);
+    LikeEntity findByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, ObjectId id, ObjectId userId);
 
-    Page<LikeEntity> findAllByUserIdAndLikeTypeOrderByCreatedAt(ObjectId userId, LikeType likeType, Pageable pageable);
+    Page<LikeEntity> findAllByUserIdAndLikeTypeAndDeletedAtIsNullOrderByCreatedAt(ObjectId userId, LikeType likeType, Pageable pageable);
 }

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/controller/ReplyCommentController.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/controller/ReplyCommentController.java
@@ -1,10 +1,9 @@
 package inu.codin.codin.domain.post.domain.reply.controller;
 
 import inu.codin.codin.common.response.SingleResponse;
-import inu.codin.codin.domain.post.domain.comment.dto.request.CommentUpdateRequestDTO;
+import inu.codin.codin.domain.post.domain.reply.dto.request.ReplyCreateRequestDTO;
 import inu.codin.codin.domain.post.domain.reply.dto.request.ReplyUpdateRequestDTO;
 import inu.codin.codin.domain.post.domain.reply.service.ReplyCommentService;
-import inu.codin.codin.domain.post.domain.reply.dto.request.ReplyCreateRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/entity/ReplyCommentEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/entity/ReplyCommentEntity.java
@@ -1,7 +1,6 @@
 package inu.codin.codin.domain.post.domain.reply.entity;
 
 import inu.codin.codin.common.BaseTimeEntity;
-import inu.codin.codin.domain.post.exception.StateUpdateException;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -15,6 +15,7 @@ import inu.codin.codin.domain.post.entity.PostEntity;
 import inu.codin.codin.domain.post.repository.PostRepository;
 import inu.codin.codin.domain.user.entity.UserEntity;
 import inu.codin.codin.domain.user.repository.UserRepository;
+import inu.codin.codin.infra.redis.RedisService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +35,9 @@ public class ReplyCommentService {
     private final PostRepository postRepository;
     private final ReplyCommentRepository replyCommentRepository;
     private final UserRepository userRepository;
+
     private final LikeService likeService;
+    private final RedisService redisService;
 
     // 대댓글 추가
     public void addReply(String id, ReplyCreateRequestDTO requestDTO) {
@@ -58,6 +61,7 @@ public class ReplyCommentService {
         // 댓글 수 증가 (대댓글도 댓글 수에 포함)
         log.info("대댓글 추가전, commentCount: {}", post.getCommentCount());
         post.updateCommentCount(post.getCommentCount() + 1);
+        redisService.applyBestScore(1, post.get_id());
         postRepository.save(post);
         log.info("대댓글 추가후, commentCount: {}", post.getCommentCount());
     }

--- a/src/main/java/inu/codin/codin/domain/post/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/scrap/controller/ScrapController.java
@@ -1,16 +1,16 @@
 package inu.codin.codin.domain.post.domain.scrap.controller;
 
 import inu.codin.codin.common.response.SingleResponse;
-import inu.codin.codin.common.security.util.SecurityUtils;
-import inu.codin.codin.domain.post.domain.like.dto.LikeRequestDto;
 import inu.codin.codin.domain.post.domain.scrap.service.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/scraps")

--- a/src/main/java/inu/codin/codin/domain/post/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/scrap/repository/ScrapRepository.java
@@ -1,7 +1,5 @@
 package inu.codin.codin.domain.post.domain.scrap.repository;
 
-import inu.codin.codin.domain.post.domain.like.entity.LikeEntity;
-import inu.codin.codin.domain.post.domain.like.entity.LikeType;
 import inu.codin.codin.domain.post.domain.scrap.entity.ScrapEntity;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
@@ -14,13 +12,11 @@ import java.util.List;
 @Repository
 public interface ScrapRepository extends MongoRepository<ScrapEntity, ObjectId> {
 
-    List<ScrapEntity> findByPostId(ObjectId postId);
+    List<ScrapEntity> findByPostIdAndDeletedAtIsNull(ObjectId postId);
 
-    long countByPostId(ObjectId postId);
+    long countByPostIdAndDeletedAtIsNull(ObjectId postId);
 
-    void deleteByPostIdAndUserId(ObjectId postId, ObjectId userId);
+    ScrapEntity findByPostIdAndUserId(ObjectId postId, ObjectId userId);
 
-    boolean existsByPostIdAndUserId(ObjectId postId, ObjectId userId);
-
-    Page<ScrapEntity> findAllByUserIdOrderByCreatedAt(ObjectId userId, PageRequest pageRequest);
+    Page<ScrapEntity> findAllByUserIdAndDeletedAtIsNullOrderByCreatedAt(ObjectId userId, PageRequest pageRequest);
 }

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -21,7 +21,6 @@ import inu.codin.codin.domain.post.repository.PostRepository;
 import inu.codin.codin.domain.user.entity.UserEntity;
 import inu.codin.codin.domain.user.entity.UserRole;
 import inu.codin.codin.domain.user.repository.UserRepository;
-import inu.codin.codin.domain.user.service.UserService;
 import inu.codin.codin.infra.redis.RedisService;
 import inu.codin.codin.infra.s3.S3Service;
 import inu.codin.codin.infra.s3.exception.ImageRemoveException;
@@ -36,6 +35,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -223,5 +223,14 @@ public class PostService {
         return user.getNickname();
     }
 
+    public List<PostDetailResponseDTO> getTop3BestPosts() {
+        Set<String> postIds = redisService.getTopNPosts(3);
+        List<PostEntity> bestPosts = postIds.stream()
+                .map(postId ->
+                    postRepository.findById(new ObjectId(postId))
+                            .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."))
+                ).toList();
+        return getPostListResponseDtos(bestPosts);
+    }
 }
 

--- a/src/main/java/inu/codin/codin/domain/user/service/UserService.java
+++ b/src/main/java/inu/codin/codin/domain/user/service/UserService.java
@@ -33,7 +33,6 @@ import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.bson.types.ObjectId;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -108,7 +107,7 @@ public class UserService {
         PageRequest pageRequest = PageRequest.of(pageNumber, 20, Sort.by("createdAt").descending());
         switch (interactionType) {
             case LIKE:
-                Page<LikeEntity> likePage = likeRepository.findAllByUserIdAndLikeTypeOrderByCreatedAt(userId, LikeType.valueOf("POST"), pageRequest);
+                Page<LikeEntity> likePage = likeRepository.findAllByUserIdAndLikeTypeAndDeletedAtIsNullOrderByCreatedAt(userId, LikeType.valueOf("POST"), pageRequest);
                 List<PostEntity> postUserLike = likePage.getContent().stream()
                         .map(likeEntity -> postRepository.findByIdAndNotDeleted(likeEntity.getLikeTypeId())
                                 .orElseThrow(() -> new NotFoundException("유저가 좋아요를 누른 게시글을 찾을 수 없습니다.")))
@@ -116,7 +115,7 @@ public class UserService {
                 return PostPageResponse.of(postService.getPostListResponseDtos(postUserLike), likePage.getTotalPages()-1, likePage.hasNext()? likePage.getPageable().getPageNumber() + 1 : -1);
 
             case SCRAP:
-                Page<ScrapEntity> scrapPage = scrapRepository.findAllByUserIdOrderByCreatedAt(userId, pageRequest);
+                Page<ScrapEntity> scrapPage = scrapRepository.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAt(userId, pageRequest);
                 List<PostEntity> postUserScrap = scrapPage.getContent().stream()
                         .map(scrapEntity -> postRepository.findByIdAndNotDeleted(scrapEntity.getPostId())
                                 .orElseThrow(() -> new NotFoundException("유저가 스크랩한 게시글을 찾을 수 없습니다.")))

--- a/src/main/java/inu/codin/codin/infra/redis/RedisService.java
+++ b/src/main/java/inu/codin/codin/infra/redis/RedisService.java
@@ -6,8 +6,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -112,5 +117,53 @@ public class RedisService {
     public Set<String> getHitsUser(ObjectId postId) {
         String redisKey = HITS_KEY + postId.toString();
         return redisTemplate.opsForSet().members(redisKey);
+    }
+
+    // Top N 게시물 조회
+    public Set<String> getTopNPosts(int N) {
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd/HH");
+
+        Map<String, Double> result = new HashMap<>();
+        for (int i = 0; i < 24; i++) {
+            String redisKey = now.minusHours(i).format(formatter);
+            Set<ZSetOperations.TypedTuple<String>> members = redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, - 1);
+            if (members != null) {
+                for (ZSetOperations.TypedTuple<String> member :members){
+                    String postId = member.getValue();
+                    Double score = member.getScore();
+                    result.put(postId, score);
+                }
+            }
+        }
+
+        return result.entrySet().stream()
+                .sorted((e1, e2) -> {
+                    int scoreComparison = Double.compare(e2.getValue(), e1.getValue());
+                    if (scoreComparison != 0) {
+                        return scoreComparison;
+                    }
+                    return Integer.compare(getHitsCount(new ObjectId(e2.getKey())), getHitsCount(new ObjectId(e1.getKey())));
+                })
+                .limit(N)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+    }
+
+    public void applyBestScore(int score, ObjectId id){
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd/HH");
+
+        String redisKey;
+        for (int i=0; i<24; i++){
+            redisKey = now.minusHours(i).format(formatter);
+            Double scoreOfBest = redisTemplate.opsForZSet().score(redisKey, id.toString());
+            if (scoreOfBest != null){
+                redisTemplate.opsForZSet().incrementScore(redisKey, id.toString(), score);
+                return;
+            }
+        }
+        redisKey = now.format(DateTimeFormatter.ofPattern("yyyyMMdd/HH"));
+        redisTemplate.opsForZSet().add(redisKey, id.toString(), score);
     }
 }

--- a/src/main/java/inu/codin/codin/infra/redis/SyncScheduler.java
+++ b/src/main/java/inu/codin/codin/infra/redis/SyncScheduler.java
@@ -69,7 +69,7 @@ public class SyncScheduler {
             ObjectId likeId = new ObjectId(likeTypeId);
 
             // (좋아요 삭제) MongoDB에서 Redis에 없는 사용자 삭제
-            List<LikeEntity> dbLikes = likeRepository.findByLikeTypeAndLikeTypeId(likeType, likeId);
+            List<LikeEntity> dbLikes = likeRepository.findByLikeTypeAndLikeTypeIdAndDeletedAtIsNull(likeType, likeId);
             for (LikeEntity dbLike : dbLikes) {
                 if (!likedUsers.contains(dbLike.getUserId().toString())) {
                     log.info("[MongoDB] 좋아요 삭제: UserID={}, EntityID={}", dbLike.getUserId(), likeId);
@@ -80,7 +80,7 @@ public class SyncScheduler {
             // (좋아요 추가) Redis에는 있지만 MongoDB에 없는 사용자 추가
             for (String id : likedUsers) {
                 ObjectId userId = new ObjectId(id);
-                if (!likeRepository.existsByLikeTypeAndLikeTypeIdAndUserId(likeType, likeId, userId)) {
+                if (!likeRepository.existsByLikeTypeAndLikeTypeIdAndUserIdAndDeletedAtIsNull(likeType, likeId, userId)) {
                     log.info("[MongoDB] 좋아요 추가: UserID={}, EntityID={}", userId, likeId);
                     LikeEntity dbLike = LikeEntity.builder()
                             .likeType(likeType)
@@ -131,7 +131,7 @@ public class SyncScheduler {
             ObjectId id = new ObjectId(postId);
 
             // MongoDB의 스크랩 데이터 가져오기
-            List<ScrapEntity> dbScraps = scrapRepository.findByPostId(id);
+            List<ScrapEntity> dbScraps = scrapRepository.findByPostIdAndDeletedAtIsNull(id);
             Set<String> dbScrappedUsers = dbScraps.stream()
                     .map(ScrapEntity::getUserId)
                     .map(ObjectId::toString)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

SC-102 (auto merge 이슈로 revert의 revert 브랜치.. 죄송 ^^;;)

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**베스트 게시글 Top3 반환**
- redis에 ZSet() 자료구조를 사용하여 comment, reply, like, scrap에 대한 기능 작동 시 해당 post에 대한 score를 반영
- 24시간(하루)에 대하여 score를 초기화 하기 위해 ,
redisKey를 yyyyMMdd/HH 형식으로 작성하여 현재 score가 반영되는 postId가 24시간 이내에 존재하는지 확인 후 반영
만약 존재한다면 해당 postId에 score를 더해주고, 없다면 새롭게 redis에 생성
또한, 하루로 유효기간을 적용
- 만약 동일한 score인 경우 hit 수가 더 많은 게시글에 따라서 랭킹 반영

- 중복된 like, scrap에 대하여 점수 반영을 금지하기 위해 softDelete로 처리
- softDelete에 따른 repository 함수 변경

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/2f7a21fb-9164-40f4-a21f-2025a127dfcf)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 하루에 지나서 초기화가 되는지 확인
- 여러 사람들 계정을 통해 score가 잘 반영되는지 확인해야 할 것 같습니다.
- 테스트 하는 분의 local 환경에서 랭킹이 잘 반영되는지 확인해주세요!
