### PR TITLE
fix : 비밀번호 재설정 시, 유효한 이메일인지 확인

### DIFF
--- a/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
@@ -1,5 +1,6 @@
 package inu.codin.codin.domain.email.service;
 
+import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.domain.email.dto.JoinEmailCheckRequestDto;
 import inu.codin.codin.domain.email.dto.JoinEmailSendRequestDto;
 import inu.codin.codin.domain.email.entity.EmailAuthEntity;
@@ -67,7 +68,7 @@ public class EmailAuthService {
     public void sendPasswordEmail(JoinEmailSendRequestDto joinEmailSendRequestDto) {
 
         userRepository.findByEmail(joinEmailSendRequestDto.getEmail())
-                .orElseThrow(() -> new EmailAuthFailException("회원가입을 먼저 진행해주세요."));
+                .orElseThrow(() -> new NotFoundException("회원가입을 먼저 진행해주세요."));
 
         String email = joinEmailSendRequestDto.getEmail();
         log.info("[sendAuthEmail] email : {}", email);

--- a/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
+++ b/src/main/java/inu/codin/codin/domain/email/service/EmailAuthService.java
@@ -5,6 +5,7 @@ import inu.codin.codin.domain.email.dto.JoinEmailSendRequestDto;
 import inu.codin.codin.domain.email.entity.EmailAuthEntity;
 import inu.codin.codin.domain.email.exception.EmailAuthFailException;
 import inu.codin.codin.domain.email.repository.EmailAuthRepository;
+import inu.codin.codin.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class EmailAuthService {
 
     private final EmailAuthRepository emailAuthRepository;
     private final EmailSendService emailSendService;
+    private final UserRepository userRepository;
 
     public void sendAuthEmail(JoinEmailSendRequestDto joinEmailSendRequestDto) {
 
@@ -63,6 +65,9 @@ public class EmailAuthService {
     }
 
     public void sendPasswordEmail(JoinEmailSendRequestDto joinEmailSendRequestDto) {
+
+        userRepository.findByEmail(joinEmailSendRequestDto.getEmail())
+                .orElseThrow(() -> new EmailAuthFailException("회원가입을 먼저 진행해주세요."));
 
         String email = joinEmailSendRequestDto.getEmail();
         log.info("[sendAuthEmail] email : {}", email);


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

회원가입 되어 있지 않은 이메일에도 비밀번호 재설정 이메일이 송신되는 버그 수정
