### PR TITLE
feat :: default profile image URL

### DIFF
--- a/src/main/java/inu/codin/codin/domain/user/service/UserService.java
+++ b/src/main/java/inu/codin/codin/domain/user/service/UserService.java
@@ -64,6 +64,12 @@ public class UserService {
         String imageUrl = null;
         if (userImage != null) imageUrl = s3Service.handleImageUpload(List.of(userImage)).get(0);
 
+        // imageUrl이 null이면 기본 이미지로 설정
+        if (imageUrl == null) {
+            imageUrl = s3Service.getDefaultProfileImageUrl(); // S3Service에서 기본 이미지 URL 가져오기
+
+        }
+
         String encodedPassword = passwordEncoder.encode(userCreateRequestDto.getPassword());
 
         validateUserCreateRequest(userCreateRequestDto);

--- a/src/main/java/inu/codin/codin/infra/s3/S3Service.java
+++ b/src/main/java/inu/codin/codin/infra/s3/S3Service.java
@@ -2,6 +2,7 @@ package inu.codin.codin.infra.s3;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import inu.codin.codin.infra.s3.exception.*;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,6 +22,10 @@ public class S3Service {
     }
     @Value("codin-s3-bucket")
     public String bucket;
+
+    @Getter
+    @Value("${cloud.aws.s3.defaultProfileImageUrl}")
+    private String defaultProfileImageUrl;
 
     private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
     private static final int MAX_FILE_COUNT = 10; // 최대 파일 개수
@@ -120,4 +125,5 @@ public class S3Service {
             deleteFile(fileUrl);
         }
     }
+
 }


### PR DESCRIPTION


## 📝 작업 내용

회원가입 시 profile image -> null 미선택시 S3 default 폴더 내부의 기본 이미지 적용
application-aws.yml 에 Default Url 설정 추가해서  resource 파일 업데이트해야 합니다

### 스크린샷 (선택)
<img width="683" alt="스크린샷 2025-01-15 오전 4 29 08" src="https://github.com/user-attachments/assets/37c5ef77-c9d1-421c-b5a5-c9e70e4508e1" />
<img width="536" alt="스크린샷 2025-01-15 오전 4 29 39" src="https://github.com/user-attachments/assets/0bb14795-9800-4626-b55e-90182e6d47a0" />

## 💬 리뷰 요구사항(선택)

resource 업데이트 해야하는데 PR 확인 이후에 Backend-resource 레포지토리 수정하면 되는건가요?
