### PR TITLE
댓글 count, 삭제된 reply 반환 버그 수정

### DIFF
--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -69,15 +69,15 @@ public class CommentService {
                 .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
         SecurityUtils.validateUser(comment.getUserId());
 
-        // 댓글의 대댓글 조회
-        List<ReplyCommentEntity> replies = replyCommentRepository.findByCommentIdAndNotDeleted(commentId);
-        // 대댓글 Soft Delete 처리
-        replies.forEach(reply -> {
-            if (reply.getDeletedAt()!=null) {
-                reply.delete();
-                replyCommentRepository.save(reply);
-            }
-        });
+//        // 댓글의 대댓글 조회
+//        List<ReplyCommentEntity> replies = replyCommentRepository.findByCommentId(commentId);
+//        // 대댓글 Soft Delete 처리
+//        replies.forEach(reply -> {
+//            if (reply.getDeletedAt()!=null) {
+//                reply.delete();
+//                replyCommentRepository.save(reply);
+//            }
+//        });
 
         // 댓글 Soft Delete 처리
         comment.delete();

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -83,14 +83,13 @@ public class CommentService {
         comment.delete();
         commentRepository.save(comment);
 
-        // 댓글 수 감소 (댓글 + 대댓글 수만큼 감소)
-        PostEntity post = postRepository.findByIdAndNotDeleted(comment.getPostId())
-                .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
-        post.updateCommentCount(post.getCommentCount() - (1 + replies.size()));
-        postRepository.save(post);
+//        // 댓글 수 감소 (댓글 + 대댓글 수만큼 감소)
+//        PostEntity post = postRepository.findByIdAndNotDeleted(comment.getPostId())
+//                .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
+//        post.updateCommentCount(post.getCommentCount() - (1 + replies.size()));
+//        postRepository.save(post);
 
-        log.info("삭제된 commentId: {} , 대댓글 {} . 총 삭제 수: {} postId: {}",
-                commentId, replies.size(), (1 + replies.size()), post.get_id());
+        log.info("삭제된 commentId: {}", commentId);
     }
 
 

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/repository/ReplyCommentRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/repository/ReplyCommentRepository.java
@@ -14,6 +14,5 @@ public interface ReplyCommentRepository extends MongoRepository<ReplyCommentEnti
     @Query("{'_id': ?0, 'deletedAt': null}")
     Optional<ReplyCommentEntity> findByIdAndNotDeleted(ObjectId id);
 
-    @Query("{'commentId':  ?0, 'deletedAt':  null}")
-    List<ReplyCommentEntity> findByCommentIdAndNotDeleted(ObjectId commentId);
+    List<ReplyCommentEntity> findByCommentId(ObjectId commentId);
 }

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -75,21 +75,21 @@ public class ReplyCommentService {
         reply.delete();
         replyCommentRepository.save(reply);
 
-        // 댓글 수 감소 (대댓글도 댓글 수에서 감소)
-        CommentEntity comment = commentRepository.findByIdAndNotDeleted(reply.getCommentId())
-                .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
+//        // 댓글 수 감소 (대댓글도 댓글 수에서 감소)
+//        CommentEntity comment = commentRepository.findByIdAndNotDeleted(reply.getCommentId())
+//                .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
+//
+//        PostEntity post = postRepository.findByIdAndNotDeleted(comment.getPostId())
+//                .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
+//        post.updateCommentCount(post.getCommentCount() - 1);
+//        postRepository.save(post);
 
-        PostEntity post = postRepository.findByIdAndNotDeleted(comment.getPostId())
-                .orElseThrow(() -> new NotFoundException("게시물을 찾을 수 없습니다."));
-        post.updateCommentCount(post.getCommentCount() - 1);
-        postRepository.save(post);
-
-        log.info("대댓글 성공적 삭제  replyId: {} , postId: {}.", replyId, post.get_id());
+        log.info("대댓글 성공적 삭제  replyId: {}", replyId);
     }
 
     // 특정 댓글의 대댓글 조회
     public List<CommentResponseDTO> getRepliesByCommentId(ObjectId commentId) {
-        List<ReplyCommentEntity> replies = replyCommentRepository.findByCommentIdAndNotDeleted(commentId);
+        List<ReplyCommentEntity> replies = replyCommentRepository.findByCommentId(commentId);
 
         Map<ObjectId, String> userNicknameMap = userRepository.findAllById(
                 replies.stream().map(ReplyCommentEntity::getUserId).distinct().toList()


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

현재 댓글 ,대댓글 모두 삭제된 내역도 반환되게끔 처리 되고 있음. 따라서 그에 따른 버그 수정

1. 댓글을 삭제하면 count가 내려가는 버그 수정 
(즉, 댓글을 하나 삭제하게 되면 삭제된 댓글 포함하여 반환은 4개가 되는데, count에는 3개로 뜨는 오류)
2. 삭제된 reply 반환이 안되는 오류 수정
3. 댓글 삭제 시 그의 대댓글 모두 삭제처리 되는 과정 제외
(또한 그에 따른 count down 처리 제외)
