### PR TITLE
Feat :: report 신고 기능 구현

### DIFF
--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostDetailResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostDetailResponseDTO.java
@@ -59,6 +59,10 @@ public class PostDetailResponseDTO {
     @Schema(description = "조회수", example = "0")
     private final int hits;
 
+    private final int reportCount;
+
+
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     @Schema(description = "생성 일자", example = "2024-12-02 20:10:18")
     private final LocalDateTime createdAt;
@@ -67,7 +71,7 @@ public class PostDetailResponseDTO {
     private final UserInfo userInfo;
 
     public PostDetailResponseDTO(String userId, String _id, String title, String content, String nickname , PostCategory postCategory, String userImageUrl, List < String > postImageUrls,
-                                 boolean isAnonymous, int likeCount, int scrapCount, int hits, LocalDateTime createdAt, int commentCount, UserInfo userInfo){
+                                 boolean isAnonymous, int likeCount, int scrapCount, int hits, LocalDateTime createdAt, int commentCount, int reportCount, UserInfo userInfo){
         this.userId = userId;
         this._id = _id;
         this.title = title;
@@ -82,6 +86,7 @@ public class PostDetailResponseDTO {
         this.commentCount = commentCount;
         this.hits = hits;
         this.createdAt = createdAt;
+        this.reportCount = reportCount;
         this.userInfo = userInfo;
     }
 
@@ -97,7 +102,7 @@ public class PostDetailResponseDTO {
         }
     }
 
-    public static PostDetailResponseDTO of(PostEntity post, String nickname, String userImageUrl, int likeCount, int scrapCount, int hitsCount, int commentCount, UserInfo userInfo) {
+    public static PostDetailResponseDTO of(PostEntity post, String nickname, String userImageUrl, int likeCount, int scrapCount, int hitsCount, int commentCount, int reportCount ,UserInfo userInfo) {
         return new PostDetailResponseDTO(
                 post.getUserId().toString(),
                 post.get_id().toString(),
@@ -113,8 +118,8 @@ public class PostDetailResponseDTO {
                 hitsCount,
                 post.getCreatedAt(),
                 commentCount,
-                userInfo
-        );
+                reportCount,
+                userInfo);
     }
 }
 

--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostPollDetailResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostPollDetailResponseDTO.java
@@ -16,7 +16,7 @@ public class PostPollDetailResponseDTO extends PostDetailResponseDTO {
     public PostPollDetailResponseDTO(PostDetailResponseDTO baseDTO, PollInfo poll) {
         super(baseDTO.getUserId(), baseDTO.get_id(), baseDTO.getTitle(), baseDTO.getContent(), baseDTO.getNickname(),
                 baseDTO.getPostCategory(), baseDTO.getUserImageUrl(), baseDTO.getPostImageUrl(), baseDTO.isAnonymous(), baseDTO.getLikeCount(),
-                baseDTO.getScrapCount(), baseDTO.getHits(), baseDTO.getCreatedAt(), baseDTO.getCommentCount(), baseDTO.getUserInfo());
+                baseDTO.getScrapCount(), baseDTO.getHits(), baseDTO.getCreatedAt(), baseDTO.getCommentCount(), baseDTO.getReportCount(), baseDTO.getUserInfo());
         this.poll = poll;
     }
 

--- a/src/main/java/inu/codin/codin/domain/post/entity/PostEntity.java
+++ b/src/main/java/inu/codin/codin/domain/post/entity/PostEntity.java
@@ -32,8 +32,11 @@ public class PostEntity extends BaseTimeEntity {
     private int likeCount = 0; // 좋아요 카운트 (redis)
     private int scrapCount = 0; // 스크랩 카운트 (redis)
 
+    private Integer reportCount = 0; // 신고 카운트
+
     @Builder
-    public PostEntity(ObjectId _id, ObjectId userId, PostCategory postCategory, String title, String content, List<String> postImageUrls ,boolean isAnonymous, PostStatus postStatus, int commentCount, int likeCount, int scrapCount) {
+    public PostEntity(ObjectId _id, ObjectId userId, PostCategory postCategory, String title, String content, List<String> postImageUrls ,boolean isAnonymous, PostStatus postStatus,
+                      int commentCount, int likeCount, int scrapCount, Integer reportCount) {
         this._id = _id;
         this.userId = userId;
         this.title = title;
@@ -45,6 +48,7 @@ public class PostEntity extends BaseTimeEntity {
         this.commentCount = commentCount;
         this.likeCount = likeCount;
         this.scrapCount = scrapCount;
+        this.reportCount = (reportCount == null) ? 0 : reportCount;
     }
 
     public void updatePostContent(String content, List<String> postImageUrls) {
@@ -80,6 +84,11 @@ public class PostEntity extends BaseTimeEntity {
     //스크랩 수 업데이트
     public void updateScrapCount(int scrapCount) {
         this.scrapCount=scrapCount;
+    }
+
+    //신고 수 업데이트
+    public void updateReportCount(int reportCount) {
+        this.reportCount=reportCount;
     }
 
 

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -158,6 +158,7 @@ public class PostService {
         int scrapCount = scrapService.getScrapCount(post.get_id());
         int hitsCount = hitsService.getHitsCount(post.get_id());
         int commentCount = post.getCommentCount();
+        int reportCount = post.getReportCount();
 
         ObjectId userId = SecurityUtils.getCurrentUserId();
 
@@ -183,14 +184,14 @@ public class PostService {
 
             //게시물 + 투표 DTO 생성
             return PostPollDetailResponseDTO.of(
-                    PostDetailResponseDTO.of(post, nickname, userImageUrl, likeCount, scrapCount, hitsCount, commentCount, userInfo),
+                    PostDetailResponseDTO.of(post, nickname, userImageUrl, likeCount, scrapCount, hitsCount, commentCount, reportCount, userInfo),
                     pollInfo
             );
         }
 
         log.info("일반 게시물 상세정보 생성 성공 PostId: {}", post.get_id());
         // 일반 게시물 처리
-        return PostDetailResponseDTO.of(post, nickname, userImageUrl, likeCount, scrapCount, hitsCount, commentCount, userInfo);
+        return PostDetailResponseDTO.of(post, nickname, userImageUrl, likeCount, scrapCount, hitsCount, commentCount, reportCount ,userInfo);
     }
 
     // 모든 글 반환 ::  게시글 내용 + 댓글+대댓글의 수 + 좋아요,스크랩 count 수 반환

--- a/src/main/java/inu/codin/codin/domain/report/controller/ReportController.java
+++ b/src/main/java/inu/codin/codin/domain/report/controller/ReportController.java
@@ -1,0 +1,94 @@
+package inu.codin.codin.domain.report.controller;
+
+import inu.codin.codin.common.response.SingleResponse;
+import inu.codin.codin.domain.like.dto.LikeRequestDto;
+import inu.codin.codin.domain.report.dto.request.ReportCreateRequestDto;
+import inu.codin.codin.domain.report.dto.request.ReportExecuteRequestDto;
+import inu.codin.codin.domain.report.dto.response.ReportResponseDto;
+import inu.codin.codin.domain.report.entity.ReportEntity;
+import inu.codin.codin.domain.report.entity.ReportStatus;
+import inu.codin.codin.domain.report.entity.ReportTargetType;
+import inu.codin.codin.domain.report.entity.ReportType;
+import inu.codin.codin.domain.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reports")
+public class ReportController {
+    private final ReportService reportService;
+
+    //신고 작성
+    /**
+      User -> User , Post, Comment, Reply
+     **/
+    @Operation(summary = "신고 하기 - 게시물, 댓글, 대댓글")
+    @PostMapping
+    public ResponseEntity<?> createReport(@RequestBody @Valid ReportCreateRequestDto reportCreateRequestDto) {
+        reportService.createReport(reportCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SingleResponse<>(201, "신고 생성 완료", null));
+    }
+
+    //신고 목록 조회 (관리자)
+    /***
+     전체조회
+     ReportType 별 조회
+     + 특정 신고횟수 이상 조회
+     */
+
+    //특정 유저 신고 상세 조회 (관리자)
+
+    //신고 처리 (관리자)
+
+    // 특정 신고 타입 목록 조회 (관리자)
+    @Operation(summary = "특정 신고 타입 목록 조회 (관리자)")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    public ResponseEntity<?> getReports(
+            @RequestParam(required = false) ReportTargetType reportTargetType,
+            @RequestParam(required = false) Integer minReportCount) {
+
+        List<ReportResponseDto> reports = reportService.getAllReports(reportTargetType, minReportCount);
+        return ResponseEntity.ok()
+                .body(new SingleResponse<>(200, "특정 신고 타입 목록 조회", reports));
+    }
+
+
+    // 특정 유저 신고 내역 조회 (관리자)
+    @Operation(summary = "특정 유저 신고 내역 조회 (관리자)")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/user")
+    public ResponseEntity<?> getReportsByUserId(
+            @RequestParam("userId") @NotNull ObjectId userId) {
+
+        List<ReportResponseDto> userReports = reportService.getReportsByUserId(userId);
+        return ResponseEntity.ok()
+                .body(new SingleResponse<>(200, "특정 유저가 신고한 내역 조회", userReports));
+    }
+
+
+    // 신고 처리 (관리자)
+    @Operation(summary = "신고 처리 (관리자)")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{reportId}")
+    public ResponseEntity<?> handleReport(
+            @RequestBody ReportExecuteRequestDto reportExecuteRequestDto) {
+
+        reportService.executeReport(reportExecuteRequestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SingleResponse<>(200, "(관리자) 신고 처리",null));
+    }
+
+}

--- a/src/main/java/inu/codin/codin/domain/report/controller/ReportController.java
+++ b/src/main/java/inu/codin/codin/domain/report/controller/ReportController.java
@@ -4,6 +4,7 @@ import inu.codin.codin.common.response.SingleResponse;
 import inu.codin.codin.domain.report.dto.request.ReportCreateRequestDto;
 import inu.codin.codin.domain.report.dto.request.ReportExecuteRequestDto;
 import inu.codin.codin.domain.report.dto.response.ReportResponseDto;
+import inu.codin.codin.domain.report.dto.response.ReportSummaryResponseDTO;
 import inu.codin.codin.domain.report.entity.ReportTargetType;
 import inu.codin.codin.domain.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +24,7 @@ import java.util.List;
 public class ReportController {
     private final ReportService reportService;
 
-    //신고 작성
+    //(User)신고 작성
     /**
       User -> User , Post, Comment, Reply
      **/
@@ -35,16 +36,15 @@ public class ReportController {
                 .body(new SingleResponse<>(201, "신고 생성 완료", null));
     }
 
-    //신고 목록 조회 (관리자)
-    /***
-     전체조회
-     ReportType 별 조회
-     + 특정 신고횟수 이상 조회
-     */
+    //(User) 특정 게시물의 신고 정보 조회 API
+    @Operation(summary = "특정 게시물의 신고 내역 조회")
+    @GetMapping("/summary/{reportTargetId}")
+    public ResponseEntity<?> getReportSummary(@PathVariable String reportTargetId) {
+        ReportSummaryResponseDTO reportSummary = reportService.getReportSummary(reportTargetId);
+        return ResponseEntity.ok()
+                .body(new SingleResponse<>(200, "특정 게시물의 신고 내역 조회 완료", reportSummary));
+    }
 
-    //특정 유저 신고 상세 조회 (관리자)
-
-    //신고 처리 (관리자)
 
     // 특정 신고 타입 목록 조회 (관리자)
     @Operation(summary = "특정 신고 타입 목록 조회 (관리자)")

--- a/src/main/java/inu/codin/codin/domain/report/controller/ReportController.java
+++ b/src/main/java/inu/codin/codin/domain/report/controller/ReportController.java
@@ -70,7 +70,7 @@ public class ReportController {
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/user")
     public ResponseEntity<?> getReportsByUserId(
-            @RequestParam("userId") @NotNull ObjectId userId) {
+            @RequestParam("userId") @NotNull String userId) {
 
         List<ReportResponseDto> userReports = reportService.getReportsByUserId(userId);
         return ResponseEntity.ok()

--- a/src/main/java/inu/codin/codin/domain/report/controller/ReportController.java
+++ b/src/main/java/inu/codin/codin/domain/report/controller/ReportController.java
@@ -1,20 +1,15 @@
 package inu.codin.codin.domain.report.controller;
 
 import inu.codin.codin.common.response.SingleResponse;
-import inu.codin.codin.domain.like.dto.LikeRequestDto;
 import inu.codin.codin.domain.report.dto.request.ReportCreateRequestDto;
 import inu.codin.codin.domain.report.dto.request.ReportExecuteRequestDto;
 import inu.codin.codin.domain.report.dto.response.ReportResponseDto;
-import inu.codin.codin.domain.report.entity.ReportEntity;
-import inu.codin.codin.domain.report.entity.ReportStatus;
 import inu.codin.codin.domain.report.entity.ReportTargetType;
-import inu.codin.codin.domain.report.entity.ReportType;
 import inu.codin.codin.domain.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.bson.types.ObjectId;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -85,7 +80,7 @@ public class ReportController {
     public ResponseEntity<?> handleReport(
             @RequestBody ReportExecuteRequestDto reportExecuteRequestDto) {
 
-        reportService.executeReport(reportExecuteRequestDto);
+        reportService.resolveReport(reportExecuteRequestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new SingleResponse<>(200, "(관리자) 신고 처리",null));

--- a/src/main/java/inu/codin/codin/domain/report/dto/request/ReportCreateRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/report/dto/request/ReportCreateRequestDto.java
@@ -1,0 +1,25 @@
+package inu.codin.codin.domain.report.dto.request;
+
+import inu.codin.codin.domain.report.entity.ReportTargetType;
+import inu.codin.codin.domain.report.entity.ReportType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.bson.types.ObjectId;
+
+@Getter
+public class ReportCreateRequestDto {
+
+    @Schema(description = "신고할 대상 타입", example = "USER, POST, COMMENT, REPLY")
+    @NotNull
+    private ReportTargetType reportTargetType;
+
+    @Schema(description = "신고 대상 타입의 ID ( 유저, 게시물, 댓글, 대댓글)", example = "2")
+    @NotBlank
+    private String reportTargetId;
+
+    @Schema(description = " 신고 유형 ( 게시글 부적절, 스팸 ,,.)", example = "INAPPROPRIATE_CONTENT, COMMERCIAL_AD , ABUSE , OBSCENE, POLITICAL,FRAUD , SPAM ,,")
+    @NotNull
+    private ReportType reportType;
+}

--- a/src/main/java/inu/codin/codin/domain/report/dto/request/ReportExecuteRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/report/dto/request/ReportExecuteRequestDto.java
@@ -1,0 +1,24 @@
+package inu.codin.codin.domain.report.dto.request;
+
+import inu.codin.codin.domain.report.entity.ReportStatus;
+import inu.codin.codin.domain.report.entity.SuspensionPeriod;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class ReportExecuteRequestDto {
+    private String reportId; // 신고 ID
+    private String comment; // 신고 처리에 대한 코멘트
+    private SuspensionPeriod suspensionPeriod; // 정지 기간
+
+    public LocalDateTime getSuspensionEndDate() {
+        if (suspensionPeriod == null) {
+            return null;
+        }
+        return LocalDateTime.now().plusDays(suspensionPeriod.getDays());
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/dto/request/ReportExecuteRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/report/dto/request/ReportExecuteRequestDto.java
@@ -15,10 +15,4 @@ public class ReportExecuteRequestDto {
     private String comment; // 신고 처리에 대한 코멘트
     private SuspensionPeriod suspensionPeriod; // 정지 기간
 
-    public LocalDateTime getSuspensionEndDate() {
-        if (suspensionPeriod == null) {
-            return null;
-        }
-        return LocalDateTime.now().plusDays(suspensionPeriod.getDays());
-    }
 }

--- a/src/main/java/inu/codin/codin/domain/report/dto/response/ReportResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/report/dto/response/ReportResponseDto.java
@@ -1,0 +1,90 @@
+package inu.codin.codin.domain.report.dto.response;
+
+import inu.codin.codin.domain.report.entity.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.bson.types.ObjectId;
+
+import inu.codin.codin.domain.report.entity.ReportTargetType;
+import inu.codin.codin.domain.report.entity.ReportType;
+import inu.codin.codin.domain.report.entity.ReportStatus;
+import inu.codin.codin.domain.report.entity.ReportEntity.ReportActionEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReportResponseDto {
+
+    @Schema(description = "report id", example = "1")
+    @NotNull
+    private String _id;
+
+    @Schema(description = "신고한 유저", example = "2")
+    @NotNull
+    private String reportingUserId;
+
+    @Schema(description = "신고당한 유저", example = "2")
+    @NotNull
+    private String reportedUserId;
+
+    @Schema(description = "신고할 대상 타입", example = "USER, POST, COMMENT, REPLY")
+    @NotNull
+    private ReportTargetType reportTargetType;
+
+    @Schema(description = "신고 대상 타입의 ID (유저, 게시물, 댓글, 대댓글)", example = "2")
+    @NotNull
+    private String reportTargetId;
+
+    @Schema(description = "신고 유형 (게시글 부적절, 스팸, ...)", example = "INAPPROPRIATE_CONTENT, COMMERCIAL_AD , ABUSE , OBSCENE, POLITICAL, FRAUD , SPAM")
+    @NotNull
+    private ReportType reportType;
+
+
+    @Schema(description = "신고 처리 상태 Pending <-> Reloved", example = "Pending, Resolved")
+    @NotNull
+    private ReportStatus reportStatus;
+
+
+    @Schema(description = "처리 정보 (ReportActionEntity)", example = "")
+    @NotNull
+    private ReportActionDto action;
+
+    @Getter
+    public static class ReportActionDto {
+        // 신고 처리 관리자 id
+        private String actionTakenById;
+
+        // 신고에 대한 코멘트
+        private String comment;
+
+        // 정지 기간 Enum
+        private String suspensionPeriod;
+
+        // 정지 종료일
+        private String suspensionEndDate;
+
+        // DTO 생성자 (ReportActionEntity로부터 데이터를 변환)
+        public ReportActionDto(ReportActionEntity actionEntity) {
+            if (actionEntity != null) {
+                this.actionTakenById = actionEntity.getActionTakenById().toString();
+                this.comment = actionEntity.getComment();
+                this.suspensionPeriod = actionEntity.getSuspensionPeriod() != null ? actionEntity.getSuspensionPeriod().name() : null;
+                this.suspensionEndDate = actionEntity.getSuspensionEndDate() != null ? actionEntity.getSuspensionEndDate().toString() : null;
+            }
+        }
+    }
+
+    // ReportEntity를 ReportResponseDto로 변환
+    public static ReportResponseDto from(ReportEntity reportEntity) {
+        return ReportResponseDto.builder()
+                ._id(reportEntity.get_id().toString())
+                .reportingUserId(reportEntity.getReportingUserId().toString())
+                .reportTargetType(reportEntity.getReportTargetType())
+                .reportTargetId(reportEntity.getReportTargetId().toString())
+                .reportType(reportEntity.getReportType())
+                .reportStatus(reportEntity.getReportStatus())
+                .action(reportEntity.getAction() != null ? new ReportActionDto(reportEntity.getAction()) : null)
+                .build();
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/dto/response/ReportResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/report/dto/response/ReportResponseDto.java
@@ -80,6 +80,7 @@ public class ReportResponseDto {
         return ReportResponseDto.builder()
                 ._id(reportEntity.get_id().toString())
                 .reportingUserId(reportEntity.getReportingUserId().toString())
+                .reportedUserId(reportEntity.getReportedUserId().toString())
                 .reportTargetType(reportEntity.getReportTargetType())
                 .reportTargetId(reportEntity.getReportTargetId().toString())
                 .reportType(reportEntity.getReportType())

--- a/src/main/java/inu/codin/codin/domain/report/dto/response/ReportSummaryResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/report/dto/response/ReportSummaryResponseDTO.java
@@ -1,0 +1,18 @@
+package inu.codin.codin.domain.report.dto.response;
+
+import inu.codin.codin.domain.report.entity.ReportType;
+import lombok.Getter;
+import org.bson.types.ObjectId;
+
+import java.util.Map;
+
+@Getter
+public class ReportSummaryResponseDTO {
+    private final Map<ReportType, Integer> reportTypeCounts;
+
+    public ReportSummaryResponseDTO(Map<ReportType, Integer> reportTypeCounts) {
+        this.reportTypeCounts = reportTypeCounts;
+    }
+}
+
+

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportEntity.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportEntity.java
@@ -47,7 +47,8 @@ public class ReportEntity extends BaseTimeEntity {
         this.reportTargetType = reportTargetType;
         this.reportTargetId = reportTargetId;
         this.reportType = reportType;
-        this.reportStatus = ReportStatus.PENDING;
+        // Null이면 PENDING, 아니면 그대로 유지
+        this.reportStatus = reportStatus != null ? reportStatus : ReportStatus.PENDING;
         this.action = action;
     }
 

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportEntity.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportEntity.java
@@ -60,15 +60,21 @@ public class ReportEntity extends BaseTimeEntity {
                 .reportTargetType(this.reportTargetType)
                 .reportTargetId(this.reportTargetId)
                 .reportType(this.reportType)
-                .reportStatus(ReportStatus.RESOLVED) // 상태 변경
+                .reportStatus(ReportStatus.SUSPENDED) // 상태 변경
                 .action(action) // 신고 처리 정보 업데이트
                 .build();
     }
 
-    public void updateReportResolved(ReportActionEntity action) {
-        this.reportStatus = ReportStatus.RESOLVED; // 상태 변경
+    public void updateReportSuspended(ReportActionEntity action) {
+        this.reportStatus = ReportStatus.SUSPENDED; // 상태 변경
         this.action = action; // 신고 처리 정보 업데이트
     }
+
+
+    public void updateReportResolved() {
+        this.reportStatus = ReportStatus.RESOLVED; // 상태 변경
+    }
+
 
 
 

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportEntity.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportEntity.java
@@ -1,0 +1,97 @@
+package inu.codin.codin.domain.report.entity;
+
+
+import inu.codin.codin.common.BaseTimeEntity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document(collection = "reports")
+@Getter
+public class ReportEntity extends BaseTimeEntity {
+    @Id
+    @NotBlank
+    private ObjectId _id;
+
+    //신고한 유저
+    private ObjectId reportingUserId;
+
+    //신고당 유저
+    private ObjectId reportedUserId;
+
+    //신고 대상 타입 ( 유저, 게시물, 댓글, 대댓글)
+    private ReportTargetType reportTargetType;
+
+    //신고 대상 ID ( 유저, 게시물, 댓글, 대댓글)
+    private ObjectId reportTargetId;
+
+    //신고 유형 ( 게시글 부적절, 스팸 ,,.)
+    private ReportType reportType;
+
+    //신고 처리 상태 Pending <-> Reloved
+    private ReportStatus reportStatus;
+
+    private ReportActionEntity action; // 처리 정보
+
+    @Builder
+    public ReportEntity(ObjectId reportingUserId, ObjectId reportedUserId, ReportTargetType reportTargetType,
+                        ObjectId reportTargetId, ReportType reportType, ReportStatus reportStatus,
+                        ReportActionEntity action) {
+        this.reportingUserId = reportingUserId;
+        this.reportedUserId = reportedUserId;
+        this.reportTargetType = reportTargetType;
+        this.reportTargetId = reportTargetId;
+        this.reportType = reportType;
+        this.reportStatus = ReportStatus.PENDING;
+        this.action = action;
+    }
+
+    // 신고 상태 업데이트 (빌더 패턴 활용)
+    public ReportEntity updateReport(ReportActionEntity action) {
+        return ReportEntity.builder()
+                .reportingUserId(this.reportingUserId)
+                .reportedUserId(this.reportedUserId)
+                .reportTargetType(this.reportTargetType)
+                .reportTargetId(this.reportTargetId)
+                .reportType(this.reportType)
+                .reportStatus(ReportStatus.RESOLVED) // 상태 변경
+                .action(action) // 신고 처리 정보 업데이트
+                .build();
+    }
+
+    public void updateReportResolved(ReportActionEntity action) {
+        this.reportStatus = ReportStatus.RESOLVED; // 상태 변경
+        this.action = action; // 신고 처리 정보 업데이트
+    }
+
+
+
+    @Getter
+    public static class ReportActionEntity extends BaseTimeEntity {
+        //신고 처리 관리자 id
+        private ObjectId actionTakenById;
+
+        //신고에 대한 코멘트
+        private String comment;
+
+        // 정지 기간 Enum
+        private SuspensionPeriod suspensionPeriod;
+
+        // 정지 종료일
+        private LocalDateTime suspensionEndDate;
+
+        @Builder
+        public ReportActionEntity(ObjectId actionTakenById, String comment,
+                                  SuspensionPeriod suspensionPeriod, LocalDateTime suspensionEndDate) {
+            this.actionTakenById = actionTakenById;
+            this.comment = comment;
+            this.suspensionPeriod = suspensionPeriod;
+            this.suspensionEndDate = suspensionEndDate;
+        }
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportStatus.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportStatus.java
@@ -1,0 +1,15 @@
+package inu.codin.codin.domain.report.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ReportStatus {
+    PENDING("대기"),
+    RESOLVED("처리 완료");
+
+    private final String description;
+
+    ReportStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportStatus.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportStatus.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum ReportStatus {
     PENDING("대기"),
+    SUSPENDED("정지 상태"),
     RESOLVED("처리 완료");
 
     private String description;

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportStatus.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportStatus.java
@@ -7,7 +7,7 @@ public enum ReportStatus {
     PENDING("대기"),
     RESOLVED("처리 완료");
 
-    private final String description;
+    private String description;
 
     ReportStatus(String description) {
         this.description = description;

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportTargetType.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportTargetType.java
@@ -1,0 +1,18 @@
+package inu.codin.codin.domain.report.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ReportTargetType {
+    USER("사용자"),
+    POST("게시물"),
+    COMMENT("댓글"),
+    REPLY("대댓글"),
+    REVIEW("수강 후기");
+
+    private final String description;
+
+    ReportTargetType(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportTargetType.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportTargetType.java
@@ -7,8 +7,7 @@ public enum ReportTargetType {
     USER("사용자"),
     POST("게시물"),
     COMMENT("댓글"),
-    REPLY("대댓글"),
-    REVIEW("수강 후기");
+    REPLY("대댓글");
 
     private final String description;
 

--- a/src/main/java/inu/codin/codin/domain/report/entity/ReportType.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/ReportType.java
@@ -1,0 +1,21 @@
+package inu.codin.codin.domain.report.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ReportType {
+    INAPPROPRIATE_CONTENT("게시판 성격에 부적절"),
+    POLITICAL("부적절한 정치적 의견"),
+    FRAUD("사칭/사기"),
+    SPAM("도배/낚시"),
+    COMMERCIAL_AD("상업적 광고"),
+    ABUSE("욕설"),
+    OBSCENE("음란물 및 불건전함");
+
+
+    private final String description;
+
+    ReportType(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/entity/SuspensionPeriod.java
+++ b/src/main/java/inu/codin/codin/domain/report/entity/SuspensionPeriod.java
@@ -1,0 +1,19 @@
+package inu.codin.codin.domain.report.entity;
+
+import lombok.Getter;
+import software.amazon.awssdk.services.s3.endpoints.internal.Value;
+
+@Getter
+public enum SuspensionPeriod {
+    ONE_DAY(1),
+    THREE_DAYS(3),
+    SEVEN_DAYS(7),
+    THIRTY_DAYS(30),
+    PERMANENT(Integer.MAX_VALUE); // 영구 정지
+
+    private final int days;
+
+    SuspensionPeriod(Integer days) {
+        this.days = days;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/exception/ReportAlreadyExistsException.java
+++ b/src/main/java/inu/codin/codin/domain/report/exception/ReportAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package inu.codin.codin.domain.report.exception;
+
+public class ReportAlreadyExistsException extends RuntimeException {
+    public ReportAlreadyExistsException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/inu/codin/codin/domain/report/exception/ReportUnsupportedTypeException.java
+++ b/src/main/java/inu/codin/codin/domain/report/exception/ReportUnsupportedTypeException.java
@@ -1,0 +1,7 @@
+package inu.codin.codin.domain.report.exception;
+
+public class ReportUnsupportedTypeException extends RuntimeException {
+    public ReportUnsupportedTypeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/repository/ReportRepository.java
+++ b/src/main/java/inu/codin/codin/domain/report/repository/ReportRepository.java
@@ -1,0 +1,36 @@
+package inu.codin.codin.domain.report.repository;
+
+import inu.codin.codin.domain.report.entity.ReportEntity;
+import inu.codin.codin.domain.report.entity.ReportTargetType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReportRepository extends MongoRepository<ReportEntity, ObjectId> {
+
+    @Query("{'reportingUserId': ?0, 'reportTargetId': ?1, 'reportTargetType': ?2}")
+    Boolean existsByReportingUserIdAndReportTargetIdAndReportTargetType(ObjectId reportingUserId, ObjectId reportTargetId, ReportTargetType reportTargetType);
+
+    List<ReportEntity> findByReportTargetType(ReportTargetType reportTargetType);
+
+    @Aggregation(pipeline = {
+            "{ $group: { _id: '$reportTargetId', count: { $sum: 1 } } }", // reportTargetId별로 그룹화하고 개수 세기
+            "{ $match: { count: { $gte: ?0 } } }" // minReportCount 이상인 count만 필터링
+    })
+    List<ReportEntity> findReportsByMinReportCount(Integer minReportCount);
+
+    List<ReportEntity> findByReportingUserId(ObjectId userId);
+
+    // 현재 정지 상태이며, 정지 종료일이 아직 남아있는 유저 조회
+    @Query("{'action.suspensionEndDate': { $gt: ?0 }}")
+    List<ReportEntity> findSuspendedUsers(LocalDateTime now);
+}

--- a/src/main/java/inu/codin/codin/domain/report/repository/ReportRepository.java
+++ b/src/main/java/inu/codin/codin/domain/report/repository/ReportRepository.java
@@ -2,6 +2,7 @@ package inu.codin.codin.domain.report.repository;
 
 import inu.codin.codin.domain.report.entity.ReportEntity;
 import inu.codin.codin.domain.report.entity.ReportTargetType;
+import inu.codin.codin.domain.report.entity.ReportType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.bson.types.ObjectId;
@@ -17,8 +18,7 @@ import java.util.Optional;
 @Repository
 public interface ReportRepository extends MongoRepository<ReportEntity, ObjectId> {
 
-    @Query("{'reportingUserId': ?0, 'reportTargetId': ?1, 'reportTargetType': ?2}")
-    Boolean existsByReportingUserIdAndReportTargetIdAndReportTargetType(ObjectId reportingUserId, ObjectId reportTargetId, ReportTargetType reportTargetType);
+    boolean existsByReportingUserIdAndReportTargetIdAndReportTargetType(ObjectId reportingUserId, ObjectId reportTargetId, ReportTargetType reportTargetType);
 
     List<ReportEntity> findByReportTargetType(ReportTargetType reportTargetType);
 
@@ -34,4 +34,10 @@ public interface ReportRepository extends MongoRepository<ReportEntity, ObjectId
     //정지 종료일(suspensionEndDate)이 현재 날짜보다 이전($lt)
     @Query("{'reportStatus': 'SUSPENDED', 'action.suspensionEndDate': { $lt: ?0 }}")
     List<ReportEntity> findSuspendedUsers(LocalDateTime now);
+
+    // 특정 게시물의 전체 신고 개수
+    int countByReportTargetId(ObjectId reportTargetId);
+
+    // 특정 게시물의 특정 신고 유형 개수
+    int countByReportTargetIdAndReportType(ObjectId reportTargetId, ReportType reportType);
 }

--- a/src/main/java/inu/codin/codin/domain/report/repository/ReportRepository.java
+++ b/src/main/java/inu/codin/codin/domain/report/repository/ReportRepository.java
@@ -31,6 +31,7 @@ public interface ReportRepository extends MongoRepository<ReportEntity, ObjectId
     List<ReportEntity> findByReportingUserId(ObjectId userId);
 
     // 현재 정지 상태이며, 정지 종료일이 아직 남아있는 유저 조회
-    @Query("{'action.suspensionEndDate': { $gt: ?0 }}")
+    //정지 종료일(suspensionEndDate)이 현재 날짜보다 이전($lt)
+    @Query("{'reportStatus': 'SUSPENDED', 'action.suspensionEndDate': { $lt: ?0 }}")
     List<ReportEntity> findSuspendedUsers(LocalDateTime now);
 }

--- a/src/main/java/inu/codin/codin/domain/report/scheduler/SuspensionScheduler.java
+++ b/src/main/java/inu/codin/codin/domain/report/scheduler/SuspensionScheduler.java
@@ -1,0 +1,21 @@
+package inu.codin.codin.domain.report.scheduler;
+
+import inu.codin.codin.domain.report.service.SuspensionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SuspensionScheduler {
+
+    private final SuspensionService suspensionService;
+
+    @Scheduled(cron = "0 0 * * * ?") // 매 정시마다 실행
+    public void checkAndReleaseSuspendedUsers() {
+        log.info("🚀 정지 해제 스케줄러 실행...");
+        suspensionService.releaseSuspendedUsers();
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/scheduler/SuspensionScheduler.java
+++ b/src/main/java/inu/codin/codin/domain/report/scheduler/SuspensionScheduler.java
@@ -13,9 +13,10 @@ public class SuspensionScheduler {
 
     private final SuspensionService suspensionService;
 
-    @Scheduled(cron = "0 0 * * * ?") // 매 정시마다 실행
+    //@Scheduled(cron = "0 0 * * * ?") // 매 정시마다 실행
+    @Scheduled(cron = "0 * * * * ?") // 매 1분마다 실행
     public void checkAndReleaseSuspendedUsers() {
-        log.info("🚀 정지 해제 스케줄러 실행...");
+        log.info("정지 해제 스케줄러 실행...");
         suspensionService.releaseSuspendedUsers();
     }
 }

--- a/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
+++ b/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
@@ -155,10 +155,13 @@ public class ReportService {
     }
 
     // 특정 유저가 신고 내역 조회 (관리자)
-    public List<ReportResponseDto> getReportsByUserId(ObjectId userId) {
+    public List<ReportResponseDto> getReportsByUserId(String userId) {
         log.info("특정 유저 신고 내역 조회: userId={}", userId);
 
-        List<ReportEntity> userReports = reportRepository.findByReportingUserId(userId);
+        ObjectId ObjUserId = new ObjectId(userId);
+
+
+        List<ReportEntity> userReports = reportRepository.findByReportingUserId(ObjUserId);
         return userReports.stream()
                 .map(ReportResponseDto::from)
                 .collect(Collectors.toList());

--- a/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
+++ b/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
@@ -1,0 +1,225 @@
+package inu.codin.codin.domain.report.service;
+
+import inu.codin.codin.common.exception.NotFoundException;
+import inu.codin.codin.common.security.util.SecurityUtils;
+import inu.codin.codin.domain.post.domain.comment.entity.CommentEntity;
+import inu.codin.codin.domain.post.domain.comment.repository.CommentRepository;
+import inu.codin.codin.domain.post.domain.reply.entity.ReplyCommentEntity;
+import inu.codin.codin.domain.post.domain.reply.repository.ReplyCommentRepository;
+import inu.codin.codin.domain.post.entity.PostEntity;
+import inu.codin.codin.domain.post.repository.PostRepository;
+import inu.codin.codin.domain.report.dto.request.ReportCreateRequestDto;
+import inu.codin.codin.domain.report.dto.request.ReportExecuteRequestDto;
+import inu.codin.codin.domain.report.dto.response.ReportResponseDto;
+import inu.codin.codin.domain.report.entity.ReportEntity;
+import inu.codin.codin.domain.report.entity.ReportStatus;
+import inu.codin.codin.domain.report.entity.ReportTargetType;
+import inu.codin.codin.domain.report.entity.SuspensionPeriod;
+import inu.codin.codin.domain.report.exception.ReportAlreadyExistsException;
+import inu.codin.codin.domain.report.repository.ReportRepository;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.domain.user.exception.UserCreateFailException;
+import inu.codin.codin.domain.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReportService {
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final ReplyCommentRepository replyRepository;
+
+
+    public void createReport(@Valid ReportCreateRequestDto reportCreateRequestDto) {
+        /***
+         * User 검증
+         * 중복신고 방지
+         * 신고 대상 유효성 검증 (reportTargetId가 유효한 대상을 참조)
+         */
+        log.info("신고 생성 요청 시작: {} ", reportCreateRequestDto);
+
+        // 신고한 유저 검증
+        ObjectId userId = SecurityUtils.getCurrentUserId();
+        ObjectId reportTargetId = new ObjectId(reportCreateRequestDto.getReportTargetId());
+
+        log.info("신고 유저 검증 완료: userId={}", userId);
+
+        // 중복 신고 방지
+        log.info("중복 신고 검증: reportingUserId={}, reportTargetId={}, reportTargetType={}",
+                userId,
+                reportCreateRequestDto.getReportTargetId(),
+                reportCreateRequestDto.getReportTargetType());
+
+        Boolean reportExists = reportRepository.existsByReportingUserIdAndReportTargetIdAndReportTargetType(
+                userId,
+                reportTargetId,
+                reportCreateRequestDto.getReportTargetType()
+        );
+
+        // null 방지: reportExists가 null이면 false로 처리
+        if (Boolean.TRUE.equals(reportExists)) {
+            log.warn("중복 신고 발견: reportingUserId={}, reportTargetId={}, reportTargetType={}",
+                    userId,
+                    reportCreateRequestDto.getReportTargetId(),
+                    reportCreateRequestDto.getReportTargetType());
+            throw new ReportAlreadyExistsException("중복신고 : 이미 해당 대상에 대한 신고를 시행했습니다.");
+        }
+
+        // 신고 대상 타입 별 유효성 검증
+        log.info("신고 대상 유효성 검증: reportTargetType={}, reportTargetId={}",
+                reportCreateRequestDto.getReportTargetType(),
+                reportCreateRequestDto.getReportTargetId());
+
+        // 신고 대상 검증 및 userId 가져오기
+        ObjectId reportedUserId = validateAndGetReportedUserId(reportCreateRequestDto.getReportTargetType(), reportTargetId);
+
+        log.info("신고 대상 유효성 검증 완료: reportTargetType={}, reportTargetId={}",
+                reportCreateRequestDto.getReportTargetType(),
+                reportCreateRequestDto.getReportTargetId());
+
+        // 신고 엔티티 생성
+        ReportEntity report = ReportEntity.builder()
+                .reportingUserId(userId)
+                .reportedUserId(reportedUserId)
+                .reportTargetId(reportTargetId)
+                .reportTargetType(reportCreateRequestDto.getReportTargetType())
+                .reportType(reportCreateRequestDto.getReportType())
+                .build();
+
+        log.info("신고 엔티티 생성 완료: {}", report);
+
+        // 신고 저장
+        reportRepository.save(report);
+        log.info("신고 저장 완료: reportId={}, reportingUserId={}, reportTargetId={}",
+                report.get_id(),
+                userId,
+                reportCreateRequestDto.getReportTargetId());
+    }
+
+    /**
+     * 신고 대상 유효성 검증 및 신고 대상 UserId 추출
+     */
+    private ObjectId validateAndGetReportedUserId(ReportTargetType reportTargetType, ObjectId reportTargetId) {
+        // 타입별 유효성 검증 로직을 Map으로 관리
+        Map<ReportTargetType, Function<ObjectId, Optional<ObjectId>>> validators = Map.of(
+                ReportTargetType.USER, Optional::of, // User의 경우, ID 자체가 신고 대상
+                ReportTargetType.POST, id -> postRepository.findById(id).map(PostEntity::getUserId),
+                ReportTargetType.COMMENT, id -> commentRepository.findById(id).map(CommentEntity::getUserId),
+                ReportTargetType.REPLY, id -> replyRepository.findById(id).map(ReplyCommentEntity::getUserId)
+        );
+
+        log.info("신고 대상 검증 및 userId 조회: reportTargetType={}, reportTargetId={}", reportTargetType, reportTargetId);
+
+        // 검증 및 userId 조회
+        return Optional.ofNullable(validators.get(reportTargetType))
+                .flatMap(validator -> validator.apply(reportTargetId))
+                .orElseThrow(() -> {
+                    log.error("유효하지 않은 신고 대상: reportTargetId={}, reportTargetType={}", reportTargetId, reportTargetType);
+                    return new NotFoundException("신고 대상(ID: " + reportTargetId + ", Type: " + reportTargetType + ")이 존재하지 않습니다.");
+                });
+    }
+
+
+
+
+    // 신고 목록 조회 (관리자)
+    public List<ReportResponseDto> getAllReports(ReportTargetType reportTargetType, Integer minReportCount) {
+        log.info("신고 목록 조회: reportType={}, minReportCount={}", reportTargetType, minReportCount);
+
+        List<ReportEntity> reports;
+        if (reportTargetType != null) {
+            reports = reportRepository.findByReportTargetType(reportTargetType);
+        } else if (minReportCount != null) {
+            reports = reportRepository.findReportsByMinReportCount(minReportCount);
+        } else {
+            reports = reportRepository.findAll();
+        }
+
+        // ReportEntity를 ReportResponseDto로 변환
+        return reports.stream()
+                .map(ReportResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    // 특정 유저가 신고 내역 조회 (관리자)
+    public List<ReportResponseDto> getReportsByUserId(ObjectId userId) {
+        log.info("특정 유저 신고 내역 조회: userId={}", userId);
+
+        List<ReportEntity> userReports = reportRepository.findByReportingUserId(userId);
+        return userReports.stream()
+                .map(ReportResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+
+
+    public void executeReport(ReportExecuteRequestDto requestDto) {
+        log.info("신고 처리 요청: {}", requestDto.getReportId());
+        ObjectId userId = SecurityUtils.getCurrentUserId();
+        ObjectId ReportId = new ObjectId(requestDto.getReportId());
+
+
+        // 신고 존재 확인
+        ReportEntity report = reportRepository.findById(ReportId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 신고가 존재하지 않습니다. ID: " + requestDto.getReportId()));
+
+        // 이미 처리된 신고인지 확인
+        if (report.getReportStatus() == ReportStatus.RESOLVED) {
+            throw new IllegalStateException("이미 처리된 신고입니다.");
+        }
+
+        // 신고 처리 정보 생성
+        ReportEntity.ReportActionEntity action = ReportEntity.ReportActionEntity.builder()
+                .actionTakenById(userId)
+                .comment(requestDto.getComment())
+                .suspensionPeriod(requestDto.getSuspensionPeriod())
+                .suspensionEndDate(requestDto.getSuspensionEndDate())
+                .build();
+
+        // 엔티티 내부에서 업데이트 메서드 호출
+        //ReportEntity updatedReport = report.updateReport(action);
+
+        // 기존 객체의 필드를 직접 수정 (새 객체 생성 X)
+        report.updateReportResolved(action);
+
+
+        //유저 Suspended - 정지 상태로 변경
+        Optional<UserEntity> user = userRepository.findById(report.getReportedUserId());
+        if (user.isEmpty()) throw new NotFoundException("존재하지 않는 회원입니다.");
+        //영구 정지
+        if (requestDto.getSuspensionPeriod() == SuspensionPeriod.PERMANENT){
+            user.get().disabledUser();
+        } else {
+            user.get().suspendUser();
+        }
+
+
+        // 업데이트된 신고 저장
+        reportRepository.save(report);
+        userRepository.save(user.get());
+        //userRepository.save(user);
+        log.info("신고가 처리되었습니다. ID: {}, 처리자: {}", report.get_id(), userId);
+
+        ReportResponseDto.from(report);
+    }
+
+
+
+
+
+
+}
+

--- a/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
+++ b/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
@@ -161,8 +161,12 @@ public class ReportService {
         ObjectId ObjUserId = new ObjectId(userId);
 
 
-        List<ReportEntity> userReports = reportRepository.findByReportingUserId(ObjUserId);
-        return userReports.stream()
+        List<ReportEntity> reports = reportRepository.findByReportingUserId(ObjUserId);
+
+        log.info("DB에서 가져온 ReportEntity 리스트:");
+        reports.forEach(report -> log.info("ID: {}, ReportStatus: {}", report.get_id(), report.getReportStatus()));
+
+        return reports.stream()
                 .map(ReportResponseDto::from)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
+++ b/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
@@ -186,10 +186,9 @@ public class ReportService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 신고가 존재하지 않습니다. ID: " + requestDto.getReportId()));
 
         // 이미 처리된 신고인지 확인
-        if (report.getReportStatus() == ReportStatus.RESOLVED) {
+        if (report.getReportStatus() == ReportStatus.SUSPENDED || report.getReportStatus() == ReportStatus.RESOLVED) {
             throw new IllegalStateException("이미 처리된 신고입니다.");
         }
-
 
         // 신고 처리 정보 생성
         ReportEntity.ReportActionEntity action = ReportEntity.ReportActionEntity.builder()
@@ -203,7 +202,7 @@ public class ReportService {
         //ReportEntity updatedReport = report.updateReport(action);
 
         // 기존 객체의 필드를 직접 수정 (새 객체 생성 X)
-        report.updateReportResolved(action);
+        report.updateReportSuspended(action);
 
 
         //유저 Suspended - 정지 상태로 변경

--- a/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
+++ b/src/main/java/inu/codin/codin/domain/report/service/ReportService.java
@@ -26,6 +26,7 @@ import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -189,12 +190,13 @@ public class ReportService {
             throw new IllegalStateException("이미 처리된 신고입니다.");
         }
 
+
         // 신고 처리 정보 생성
         ReportEntity.ReportActionEntity action = ReportEntity.ReportActionEntity.builder()
                 .actionTakenById(userId)
                 .comment(requestDto.getComment())
                 .suspensionPeriod(requestDto.getSuspensionPeriod())
-                .suspensionEndDate(requestDto.getSuspensionEndDate())
+                .suspensionEndDate(LocalDateTime.now().plusDays(requestDto.getSuspensionPeriod().getDays()))
                 .build();
 
         // 엔티티 내부에서 업데이트 메서드 호출

--- a/src/main/java/inu/codin/codin/domain/report/service/SuspensionService.java
+++ b/src/main/java/inu/codin/codin/domain/report/service/SuspensionService.java
@@ -1,0 +1,38 @@
+package inu.codin.codin.domain.report.service;
+
+import inu.codin.codin.domain.report.entity.ReportEntity;
+import inu.codin.codin.domain.report.repository.ReportRepository;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SuspensionService {
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+
+    public void releaseSuspendedUsers() {
+        LocalDateTime now = LocalDateTime.now();
+        List<ReportEntity> suspendedUsers = reportRepository.findSuspendedUsers(now);
+
+        for (ReportEntity report : suspendedUsers) {
+            Optional<UserEntity> userOpt = userRepository.findById(report.getReportedUserId());
+            if (userOpt.isEmpty()) continue;
+
+            UserEntity user = userOpt.get();
+            user.activateUser(); // 정지 해제
+            userRepository.save(user); // DB 반영
+
+            log.info("유저 {} 정지 해제 완료", user.get_id());
+        }
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/report/service/SuspensionService.java
+++ b/src/main/java/inu/codin/codin/domain/report/service/SuspensionService.java
@@ -30,7 +30,11 @@ public class SuspensionService {
 
             UserEntity user = userOpt.get();
             user.activateUser(); // 정지 해제
+            report.updateReportResolved();
+
             userRepository.save(user); // DB 반영
+            reportRepository.save(report);
+
 
             log.info("유저 {} 정지 해제 완료", user.get_id());
         }

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.security.core.parameters.P;
 
 @Document(collection = "users")
 @Getter
@@ -86,6 +87,8 @@ public class UserEntity extends BaseTimeEntity {
         this.status = UserStatus.DISABLED;
     }
     public void activateUser() {
-        this.status = UserStatus.ACTIVE;
+        if ( this.status == UserStatus.SUSPENDED) {
+            this.status = UserStatus.ACTIVE;
+        }
     }
 }

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -78,4 +78,14 @@ public class UserEntity extends BaseTimeEntity {
                 .status(UserStatus.ACTIVE)
                 .build();
     }
+
+    public void suspendUser() {
+        this.status = UserStatus.SUSPENDED;
+    }
+    public void disabledUser() {
+        this.status = UserStatus.DISABLED;
+    }
+    public void activateUser() {
+        this.status = UserStatus.ACTIVE;
+    }
 }


### PR DESCRIPTION


## 📝 작업 내용

신고 기능 구현 완료.

주요 로직 흐름 :

유저 -> 특정 대상 (유저, 게시글, 댓글, 대댓글) 신고
관리자 -> 신고 내역 확인 및 처리
신고 대상 유저 -> 관리자 설정 기간 만큼 정지 or 영구정지로 전환
+ 일정기간 이상 정지된 사용자 -> 자동 Activate 스케줄링



1. 신고 생성
- 특정 대상 신고 
- 중복 신고 방지, 신고 대상 유효성 검증 로직 포함
- 게시글, 댓글, 대댓글 -> 신고 대상 사용자 ID 추출 후 저장
- 신고 유형 ( 게시글 부적절, 스팸 ,,.) 사용
- 신고 처리 상태 Pending <-> Reloved ( 신고 처리완료시)


1. (관리자) 신고 처리 
- 신고 대상 사용자를 일정 기간 정지하거나 영구 정지 가능 (1~30 +영구정지)
- 신고 처리시 사용자 Suspended 로 상태 변경 ( 영구정지 = Disabled)

2. (관리자) 전체 신고 목록 조회
- 특정 대상 선택 가능
- 신고 최소 개수 조절 가능 ( 숫자 3 선택시 3회 이상 신고 받은 대상 반환)
       - reportTargetId별로 그룹화하고 개수 세기 

3. (관리자) 특정 유저가 신고한 목록 조회 
- 

(스케쥴링)정지 해제
- 일정 기간 마다 suspended 인 유저 중 정지 기한이 지난 유저 Active 로 전환





### 스크린샷 (선택)
<img width="1002" alt="스크린샷 2025-01-29 오후 6 57 18" src="https://github.com/user-attachments/assets/4bf58b6a-94d9-4291-8eb3-d776c9c6c2a3" />
<img width="502" alt="스크린샷 2025-01-29 오후 7 04 12" src="https://github.com/user-attachments/assets/bdec8f8f-b21f-4eee-a30f-9c583c48d2a4" />
<img width="447" alt="스크린샷 2025-01-29 오후 7 08 16" src="https://github.com/user-attachments/assets/ad98f205-daaa-4065-b50d-35204eab12a2" />
<img width="677" alt="스크린샷 2025-01-29 오후 7 23 13" src="https://github.com/user-attachments/assets/c94a4ce5-30aa-4333-a2a2-9612c00fedfb" />






## 💬 리뷰 요구사항(선택)

사용자는 신고하기 API 만 있을것 같다고 판단했습니다.
관리자의 경우 추가 API 가 필요한게 있을까요?

로직 최대한 직관적으로 구성했는데 변경이 필요하면 말해주세요!




