### PR TITLE
Feat/notification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ dependencyManagement {
 	}
 }
 dependencies {
-
+	// FCM
+	implementation 'com.google.firebase:firebase-admin:7.3.0'
 	// JWT Token
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'

--- a/src/main/java/inu/codin/codin/common/BaseTimeEntity.java
+++ b/src/main/java/inu/codin/codin/common/BaseTimeEntity.java
@@ -1,7 +1,9 @@
 package inu.codin.codin.common;
 
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -13,11 +15,16 @@ public abstract class BaseTimeEntity {
     @CreatedDate
     @Field("created_at")
     private LocalDateTime createdAt;
+    @CreatedBy
+    private String createdUser;
 
     @LastModifiedDate
     @Field("updated_at")
     private LocalDateTime updatedAt;
+    @LastModifiedBy
+    private String updatedUser;
 
+    @Field("deleted_at")
     private LocalDateTime deletedAt;
 
     public void delete() {

--- a/src/main/java/inu/codin/codin/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/inu/codin/codin/common/security/jwt/JwtTokenProvider.java
@@ -1,6 +1,6 @@
 package inu.codin.codin.common.security.jwt;
 
-import inu.codin.codin.common.security.service.RedisStorageService;
+import inu.codin.codin.infra.redis.RedisStorageService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/inu/codin/codin/common/security/service/JwtService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/JwtService.java
@@ -5,6 +5,7 @@ import inu.codin.codin.common.security.exception.SecurityErrorCode;
 import inu.codin.codin.common.security.jwt.JwtAuthenticationToken;
 import inu.codin.codin.common.security.jwt.JwtTokenProvider;
 import inu.codin.codin.common.security.jwt.JwtUtils;
+import inu.codin.codin.infra.redis.RedisStorageService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/inu/codin/codin/domain/chat/chatroom/service/ChatRoomService.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatroom/service/ChatRoomService.java
@@ -53,7 +53,7 @@ public class ChatRoomService {
         log.info("[채팅방 생성 완료] 채팅방 ID: {}, 송신자 ID: {}, 수신자 ID: {}", chatRoom.get_id(), senderId, chatRoomCreateRequestDto.getReceiverId());
 
         for (Participants participant : chatRoom.getParticipants()){
-            if (participant.getUserId() != senderId && participant.isNotificationsEnabled()){
+            if (!participant.getUserId().equals(senderId) && participant.isNotificationsEnabled()){
                 notificationService.sendNotificationMessageByChat(participant.getUserId(), chatRoom);
             }
         }

--- a/src/main/java/inu/codin/codin/domain/chat/chatroom/service/ChatRoomService.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatroom/service/ChatRoomService.java
@@ -4,11 +4,13 @@ import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.domain.chat.chatroom.dto.ChatRoomCreateRequestDto;
 import inu.codin.codin.domain.chat.chatroom.dto.ChatRoomListResponseDto;
 import inu.codin.codin.domain.chat.chatroom.entity.ChatRoom;
+import inu.codin.codin.domain.chat.chatroom.entity.Participants;
 import inu.codin.codin.domain.chat.chatroom.exception.ChatRoomCreateFailException;
 import inu.codin.codin.domain.chat.chatroom.exception.ChatRoomNotFoundException;
 import inu.codin.codin.domain.chat.chatroom.repository.ChatRoomRepository;
 import inu.codin.codin.domain.chat.chatting.entity.Chatting;
 import inu.codin.codin.domain.chat.chatting.repository.CustomChattingRepository;
+import inu.codin.codin.domain.notification.service.NotificationService;
 import inu.codin.codin.domain.user.repository.UserRepository;
 import inu.codin.codin.domain.user.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class ChatRoomService {
+
+    private final NotificationService notificationService;
 
     private final ChatRoomRepository chatRoomRepository;
     private final CustomChattingRepository customChattingRepository;
@@ -47,6 +51,12 @@ public class ChatRoomService {
         ChatRoom chatRoom = ChatRoom.of(chatRoomCreateRequestDto, senderId);
         chatRoomRepository.save(chatRoom);
         log.info("[채팅방 생성 완료] 채팅방 ID: {}, 송신자 ID: {}, 수신자 ID: {}", chatRoom.get_id(), senderId, chatRoomCreateRequestDto.getReceiverId());
+
+        for (Participants participant : chatRoom.getParticipants()){
+            if (participant.getUserId() != senderId && participant.isNotificationsEnabled()){
+                notificationService.sendNotificationMessageByChat(participant.getUserId(), chatRoom);
+            }
+        }
 
         Map<String, String> response = new HashMap<>();
         response.put("chatRoomId", chatRoom.get_id().toString());

--- a/src/main/java/inu/codin/codin/domain/chat/chatting/service/ChattingService.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatting/service/ChattingService.java
@@ -52,12 +52,12 @@ public class ChattingService {
 
         chattingRepository.save(chatting);
         log.info("Message [{}] send by member: {} to chatting room: {}", chattingRequestDto.getContent(), userId, id);
-        //Receiver의 알림 체크 후, 메세지 전송
-        for (Participants participant : chatRoom.getParticipants()){
-            if (participant.getUserId() != userId && participant.isNotificationsEnabled()){
-                notificationService.sendNotificationMessageByChat(participant.getUserId(), chattingRequestDto, chatRoom);
-            }
-        }
+//        //Receiver의 알림 체크 후, 메세지 전송
+//        for (Participants participant : chatRoom.getParticipants()){
+//            if (participant.getUserId() != userId && participant.isNotificationsEnabled()){
+//                notificationService.sendNotificationMessageByChat(participant.getUserId(), chattingRequestDto, chatRoom);
+//            }
+//        }
         return ChattingResponseDto.of(chatting);
     }
 

--- a/src/main/java/inu/codin/codin/domain/chat/chatting/service/ChattingService.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatting/service/ChattingService.java
@@ -2,6 +2,7 @@ package inu.codin.codin.domain.chat.chatting.service;
 
 import inu.codin.codin.common.security.util.SecurityUtils;
 import inu.codin.codin.domain.chat.chatroom.entity.ChatRoom;
+import inu.codin.codin.domain.chat.chatroom.entity.Participants;
 import inu.codin.codin.domain.chat.chatroom.exception.ChatRoomNotFoundException;
 import inu.codin.codin.domain.chat.chatroom.repository.ChatRoomRepository;
 import inu.codin.codin.domain.chat.chatting.dto.request.ChattingRequestDto;
@@ -9,6 +10,7 @@ import inu.codin.codin.domain.chat.chatting.dto.response.ChattingAndUserIdRespon
 import inu.codin.codin.domain.chat.chatting.dto.response.ChattingResponseDto;
 import inu.codin.codin.domain.chat.chatting.entity.Chatting;
 import inu.codin.codin.domain.chat.chatting.repository.ChattingRepository;
+import inu.codin.codin.domain.notification.service.NotificationService;
 import inu.codin.codin.domain.user.security.CustomUserDetails;
 import inu.codin.codin.infra.s3.S3Service;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +34,7 @@ public class ChattingService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChattingRepository chattingRepository;
     private final S3Service s3Service;
-
-    //todo 이미지 채팅에 따른 S3 처리
+    private final NotificationService notificationService;
 
     public ChattingResponseDto sendMessage(String id, ChattingRequestDto chattingRequestDto, Authentication authentication) {
         log.info("[메시지 전송] 채팅방 ID: {}, 내용: {}", id, chattingRequestDto.getContent());
@@ -50,6 +51,13 @@ public class ChattingService {
         log.info("[메시지 전송 성공] 메시지: [{}], 송신자 ID: {}, 채팅방 ID: {}", chattingRequestDto.getContent(), userId, id);
 
         chattingRepository.save(chatting);
+        log.info("Message [{}] send by member: {} to chatting room: {}", chattingRequestDto.getContent(), userId, id);
+        //Receiver의 알림 체크 후, 메세지 전송
+        for (Participants participant : chatRoom.getParticipants()){
+            if (participant.getUserId() != userId && participant.isNotificationsEnabled()){
+                notificationService.sendNotificationMessageByChat(participant.getUserId(), chattingRequestDto, chatRoom);
+            }
+        }
         return ChattingResponseDto.of(chatting);
     }
 

--- a/src/main/java/inu/codin/codin/domain/chat/chatting/service/ChattingService.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatting/service/ChattingService.java
@@ -2,7 +2,6 @@ package inu.codin.codin.domain.chat.chatting.service;
 
 import inu.codin.codin.common.security.util.SecurityUtils;
 import inu.codin.codin.domain.chat.chatroom.entity.ChatRoom;
-import inu.codin.codin.domain.chat.chatroom.entity.Participants;
 import inu.codin.codin.domain.chat.chatroom.exception.ChatRoomNotFoundException;
 import inu.codin.codin.domain.chat.chatroom.repository.ChatRoomRepository;
 import inu.codin.codin.domain.chat.chatting.dto.request.ChattingRequestDto;
@@ -24,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/inu/codin/codin/domain/notification/NotificationController.java
+++ b/src/main/java/inu/codin/codin/domain/notification/NotificationController.java
@@ -1,0 +1,28 @@
+package inu.codin.codin.domain.notification;
+
+import inu.codin.codin.common.response.SingleResponse;
+import inu.codin.codin.domain.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notification")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "알림 읽기")
+    @GetMapping("/{notificationId}")
+    public ResponseEntity<SingleResponse<?>> readNotification(@PathVariable String notificationId){
+        notificationService.readNotification(notificationId);
+        return ResponseEntity.ok()
+                .body(new SingleResponse<>(200, "알림 읽기 완료", null));
+    }
+
+}

--- a/src/main/java/inu/codin/codin/domain/notification/NotificationController.java
+++ b/src/main/java/inu/codin/codin/domain/notification/NotificationController.java
@@ -1,5 +1,6 @@
 package inu.codin.codin.domain.notification;
 
+import inu.codin.codin.common.response.ListResponse;
 import inu.codin.codin.common.response.SingleResponse;
 import inu.codin.codin.domain.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +17,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final NotificationService notificationService;
+
+    @Operation(
+            summary = "알림 내역 반환"
+    )
+    @GetMapping()
+    public ResponseEntity<ListResponse<?>> getNotifications(){
+        return ResponseEntity.ok()
+                .body(new ListResponse<>(200, "알림 내역 반환 완료",
+                        notificationService.getNotification()));
+    }
 
     @Operation(summary = "알림 읽기")
     @GetMapping("/{notificationId}")

--- a/src/main/java/inu/codin/codin/domain/notification/dto/NotificationListResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/notification/dto/NotificationListResponseDto.java
@@ -1,0 +1,41 @@
+package inu.codin.codin.domain.notification.dto;
+
+import inu.codin.codin.domain.notification.entity.NotificationEntity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+
+@Getter
+public class NotificationListResponseDto {
+    @Id
+    @NotBlank
+    private String id;
+
+    private String targetId;
+
+    private String title;
+
+    private String message;
+
+    private boolean isRead = false;
+
+    @Builder
+    public NotificationListResponseDto(String id, String targetId, String title, String message, boolean isRead) {
+        this.id = id;
+        this.targetId = targetId;
+        this.title = title;
+        this.message = message;
+        this.isRead = isRead;
+    }
+
+    public static NotificationListResponseDto of(NotificationEntity notificationEntity){
+        return NotificationListResponseDto.builder()
+                .id(notificationEntity.getId().toString())
+                .title(notificationEntity.getTitle())
+                .message(notificationEntity.getMessage())
+                .targetId(notificationEntity.getTargetId().toString())
+                .isRead(notificationEntity.isRead())
+                .build();
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/inu/codin/codin/domain/notification/entity/NotificationEntity.java
@@ -1,0 +1,51 @@
+package inu.codin.codin.domain.notification.entity;
+
+import inu.codin.codin.common.BaseTimeEntity;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+
+@Document(collection = "notification")
+public class NotificationEntity extends BaseTimeEntity {
+
+    @Id @NotBlank
+    private ObjectId id;
+
+    @DBRef(lazy = true)
+    private UserEntity user;
+
+    private String title;
+
+    private String message;
+
+    private boolean isRead = false;
+
+    private LocalDateTime readAt;
+
+    // push, email ...
+    private String type;
+
+    // 알림 중요도 - 미사용중
+    private String priority;
+
+    @Builder
+    public NotificationEntity(UserEntity user, String title, String message, String type, String priority) {
+        this.user = user;
+        this.title = title;
+        this.message = message;
+        this.type = type;
+        this.priority = priority;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+        this.readAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/inu/codin/codin/domain/notification/entity/NotificationEntity.java
@@ -3,7 +3,10 @@ package inu.codin.codin.domain.notification.entity;
 import inu.codin.codin.common.BaseTimeEntity;
 import inu.codin.codin.domain.user.entity.UserEntity;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -13,6 +16,8 @@ import java.time.LocalDateTime;
 
 
 @Document(collection = "notification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class NotificationEntity extends BaseTimeEntity {
 
     @Id @NotBlank
@@ -20,6 +25,8 @@ public class NotificationEntity extends BaseTimeEntity {
 
     @DBRef(lazy = true)
     private UserEntity user;
+
+    private ObjectId targetId;
 
     private String title;
 
@@ -36,8 +43,9 @@ public class NotificationEntity extends BaseTimeEntity {
     private String priority;
 
     @Builder
-    public NotificationEntity(UserEntity user, String title, String message, String type, String priority) {
+    public NotificationEntity(UserEntity user, ObjectId targetId, String title, String message, String type, String priority) {
         this.user = user;
+        this.targetId = targetId;
         this.title = title;
         this.message = message;
         this.type = type;

--- a/src/main/java/inu/codin/codin/domain/notification/entity/NotificationPreference.java
+++ b/src/main/java/inu/codin/codin/domain/notification/entity/NotificationPreference.java
@@ -1,0 +1,41 @@
+package inu.codin.codin.domain.notification.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// 알림 설정
+@NoArgsConstructor
+@Getter
+public class NotificationPreference {
+
+    // 푸시 알림 허용 여부
+    private boolean allowPush = true;
+
+    // 이메일 알림 허용 여부
+    private boolean allowEmail = true;
+
+    // 알림 설정
+    private Preference preference = new Preference();
+
+    @Builder
+    public NotificationPreference(boolean allowPush, boolean allowEmail, Preference preference) {
+        this.allowPush = allowPush;
+        this.allowEmail = allowEmail;
+        this.preference = preference;
+    }
+
+    @Getter
+    @Setter
+    class Preference {
+        // 댓글 알림
+        private boolean notifyOnComment = true;
+        // 좋아요 알림
+        private boolean notifyOnLike = true;
+        // 답글 알림
+        private boolean notifyOnReply = true;
+        // 베스트 게시글 선정 알림
+        private boolean notifyOnBestPost = true;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/notification/entity/NotificationPriority.java
+++ b/src/main/java/inu/codin/codin/domain/notification/entity/NotificationPriority.java
@@ -1,0 +1,7 @@
+package inu.codin.codin.domain.notification.entity;
+
+public enum NotificationPriority {
+    HIGH,
+    MEDIUM,
+    LOW
+}

--- a/src/main/java/inu/codin/codin/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/inu/codin/codin/domain/notification/repository/NotificationRepository.java
@@ -7,8 +7,12 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NotificationRepository extends MongoRepository<NotificationEntity, ObjectId> {
     @Query("{ 'user': ?0, 'isRead': false, deletedAt: null }")
     long countUnreadNotificationsByUser(UserEntity user);
+
+    List<NotificationEntity> findAllByUser(UserEntity user);
 }

--- a/src/main/java/inu/codin/codin/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/inu/codin/codin/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package inu.codin.codin.domain.notification.repository;
+
+import inu.codin.codin.domain.notification.entity.NotificationEntity;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends MongoRepository<NotificationEntity, ObjectId> {
+    @Query("{ 'user': ?0, 'isRead': false, deletedAt: null }")
+    long countUnreadNotificationsByUser(UserEntity user);
+}

--- a/src/main/java/inu/codin/codin/domain/notification/service/NotificationService.java
+++ b/src/main/java/inu/codin/codin/domain/notification/service/NotificationService.java
@@ -3,7 +3,6 @@ package inu.codin.codin.domain.notification.service;
 import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.common.security.util.SecurityUtils;
 import inu.codin.codin.domain.chat.chatroom.entity.ChatRoom;
-import inu.codin.codin.domain.chat.chatting.dto.request.ChattingRequestDto;
 import inu.codin.codin.domain.like.entity.LikeType;
 import inu.codin.codin.domain.notification.dto.NotificationListResponseDto;
 import inu.codin.codin.domain.notification.entity.NotificationEntity;

--- a/src/main/java/inu/codin/codin/domain/notification/service/NotificationService.java
+++ b/src/main/java/inu/codin/codin/domain/notification/service/NotificationService.java
@@ -1,0 +1,197 @@
+package inu.codin.codin.domain.notification.service;
+
+import inu.codin.codin.common.exception.NotFoundException;
+import inu.codin.codin.domain.chat.chatroom.entity.ChatRoom;
+import inu.codin.codin.domain.chat.chatting.dto.request.ChattingRequestDto;
+import inu.codin.codin.domain.notification.entity.NotificationEntity;
+import inu.codin.codin.domain.notification.repository.NotificationRepository;
+import inu.codin.codin.domain.post.domain.comment.entity.CommentEntity;
+import inu.codin.codin.domain.post.domain.comment.repository.CommentRepository;
+import inu.codin.codin.domain.post.domain.like.entity.LikeType;
+import inu.codin.codin.domain.post.domain.reply.entity.ReplyCommentEntity;
+import inu.codin.codin.domain.post.domain.reply.repository.ReplyCommentRepository;
+import inu.codin.codin.domain.post.entity.PostEntity;
+import inu.codin.codin.domain.post.repository.PostRepository;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.domain.user.repository.UserRepository;
+import inu.codin.codin.infra.fcm.dto.FcmMessageTopicDto;
+import inu.codin.codin.infra.fcm.dto.FcmMessageUserDto;
+import inu.codin.codin.infra.fcm.service.FcmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final ReplyCommentRepository replyCommentRepository;
+
+    private final FcmService fcmService;
+    private final String NOTI_COMMENT_TITLE = "누군가가 내 게시글에 댓글을 달았어요!";
+    private final String NOTI_REPLY_TITLE = "누군가가 내 댓글에 답글을 달았어요!";
+    private final String NOTI_LIKE_TITLE = "나에게 첫 좋아요가 달렸어요!";
+    private final String NOTI_CHAT_TITLE = "에서 연락이 왔어요!";
+
+
+    /**
+     * 특정 유저의 읽지 않은 알림 개수를 반환
+     * @param user 알림 수신자
+     * @return 읽지 않은 알림 개수
+     */
+    public long getUnreadNotificationCount(UserEntity user) {
+        return notificationRepository.countUnreadNotificationsByUser(user);
+    }
+
+    /**
+     * FCM 메시지를 특정 사용자에게 전송하는 로직
+     * @param title 메시지 제목
+     * @param body 메시지 내용
+     * @param data 알림 대상의 _id
+     * @param user 메시지를 받을 사용자
+     */
+    public void sendFcmMessageToUser(String title, String body, Map<String, String> data, UserEntity user) {
+        FcmMessageUserDto msgDto = FcmMessageUserDto.builder()
+                .user(user)
+                .title(title)
+                .body(body)
+                .data(data)
+//                .imageUrl() //codin 로고 url
+                .build();
+
+        try {
+            fcmService.sendFcmMessage(msgDto);
+            log.info("[sendFcmMessage] 알림 전송 성공");
+            saveNotificationLog(msgDto);
+        } catch (Exception e) {
+            log.error("[sendFcmMessage] 알림 전송 실패 : {}", e.getMessage());
+        }
+    }
+
+    /**
+     * FCM 메시지를 Topic을 구독한 사람들에게 전송하는 로직
+     * @param title
+     * @param body
+     * @param data
+     * @param imageUrl
+     * @param topic
+     */
+    public void sendFcmMessageToTopic(String title, String body, Map<String, String> data, String imageUrl, String topic) {
+        FcmMessageTopicDto msgDto = FcmMessageTopicDto.builder()
+                .topic(topic)
+                .title(title)
+                .body(body)
+                .data(data)
+                .imageUrl(imageUrl)
+                .build();
+
+        try {
+            fcmService.sendFcmMessageByTopic(msgDto);
+            log.info("[sendFcmMessage] 알림 전송 성공");
+            saveNotificationLog(msgDto);
+        } catch (Exception e) {
+            log.error("[sendFcmMessage] 알림 전송 실패 : {}", e.getMessage());
+        }
+    }
+
+    // 알림 로그를 저장하는 로직 (특정 사용자 대상)
+    private void saveNotificationLog(FcmMessageUserDto msgDto) {
+        NotificationEntity notificationEntity = NotificationEntity.builder()
+                .user(msgDto.getUser())
+                .title(msgDto.getTitle())
+                .message(msgDto.getBody())
+                .type("push")
+                .priority("high")
+                .build();
+        notificationRepository.save(notificationEntity);
+    }
+
+    // 알림 로그를 저장하는 로직 (토픽 대상)
+    private void saveNotificationLog(FcmMessageTopicDto msgDto) {
+        NotificationEntity notificationEntity = NotificationEntity.builder()
+                .title(msgDto.getTitle())
+                .message(msgDto.getBody())
+                .type("topic")
+                .priority("high")
+                .build();
+        notificationRepository.save(notificationEntity);
+    }
+
+    public void sendNotificationMessageByComment(ObjectId userId, String postId, String content) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+        Map<String, String> post = new HashMap<>();
+        post.put("postId", postId);
+        sendFcmMessageToUser(NOTI_COMMENT_TITLE, content, post, user);
+    }
+
+    public void sendNotificationMessageByReply(ObjectId userId, String postId, String content) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+        Map<String, String> post = new HashMap<>();
+        post.put("postId", postId);
+        sendFcmMessageToUser(NOTI_REPLY_TITLE, content, post, user);
+    }
+
+    public void sendNotificationMessageByLike(LikeType likeType, ObjectId id) {
+        switch(likeType){
+            case POST -> {
+                PostEntity postEntity = postRepository.findByIdAndNotDeleted(id)
+                        .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."));
+                UserEntity user = userRepository.findById(postEntity.getUserId())
+                        .orElseThrow(() -> new NotFoundException("유저 정보를 찾을 수 없습니다."));
+                Map<String, String> post = new HashMap<>();
+                post.put("postId", postEntity.get_id().toString());
+                sendFcmMessageToUser(NOTI_LIKE_TITLE, "내 게시글 보러 가기", post, user);
+            }
+            case REPLY -> {
+                ReplyCommentEntity replyCommentEntity = replyCommentRepository.findByIdAndNotDeleted(id)
+                        .orElseThrow(() -> new NotFoundException("대댓글을 찾을 수 없습니다."));
+                CommentEntity commentEntity = commentRepository.findByIdAndNotDeleted(replyCommentEntity.getCommentId())
+                        .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
+                PostEntity postEntity = postRepository.findByIdAndNotDeleted(commentEntity.getPostId())
+                        .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."));
+                UserEntity user = userRepository.findById(replyCommentEntity.getUserId())
+                        .orElseThrow(() -> new NotFoundException("유저 정보를 찾을 수 없습니다."));
+                Map<String, String> post = new HashMap<>();
+                post.put("postId", postEntity.get_id().toString());
+                sendFcmMessageToUser(NOTI_LIKE_TITLE, "내 답글 보러 가기", post, user);
+            }
+            case COMMENT -> {
+                CommentEntity commentEntity = commentRepository.findByIdAndNotDeleted(id)
+                        .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
+                PostEntity postEntity = postRepository.findByIdAndNotDeleted(commentEntity.getPostId())
+                        .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."));
+                UserEntity user = userRepository.findById(commentEntity.getUserId())
+                        .orElseThrow(() -> new NotFoundException("유저 정보를 찾을 수 없습니다."));
+                Map<String, String> post = new HashMap<>();
+                post.put("postId", postEntity.get_id().toString());
+                sendFcmMessageToUser(NOTI_LIKE_TITLE, "내 댓글 보러 가기", post, user);
+            }
+        }
+    }
+
+    public void sendNotificationMessageByChat(ObjectId userId, ChattingRequestDto chattingRequestDto, ChatRoom chatRoom) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("유저 정보를 찾을 수 없습니다."));
+        Map<String, String> chat = new HashMap<>();
+        chat.put("chatRoomId", chatRoom.get_id().toString());
+        sendFcmMessageToUser(chatRoom.getRoomName()+NOTI_CHAT_TITLE, chattingRequestDto.getContent(), chat, user);
+    }
+
+    public void readNotification(String notificationId){
+        NotificationEntity notificationEntity = notificationRepository.findById(new ObjectId(notificationId))
+                .orElseThrow(() -> new NotFoundException("해당 알림을 찾을 수 없습니다."));
+        notificationEntity.markAsRead();
+        notificationRepository.save(notificationEntity);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -66,7 +66,8 @@ public class CommentService {
         redisService.applyBestScore(1, postId);
         postRepository.save(post);
         log.info("댓글 추가완료 postId: {}.", postId);
-        if (userId != post.getUserId()) notificationService.sendNotificationMessageByComment(post.getPostCategory(), post.getUserId(), post.get_id().toString(), comment.getContent());
+        if (!userId.equals(post.getUserId())) notificationService.sendNotificationMessageByComment(post.getPostCategory(), post.getUserId(), post.get_id().toString(), comment.getContent());
+
     }
 
     // 댓글 삭제 (Soft Delete)

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package inu.codin.codin.domain.post.domain.comment.service;
 
 import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.common.security.util.SecurityUtils;
+import inu.codin.codin.domain.notification.service.NotificationService;
 import inu.codin.codin.domain.post.domain.comment.dto.request.CommentCreateRequestDTO;
 import inu.codin.codin.domain.post.domain.comment.dto.request.CommentUpdateRequestDTO;
 import inu.codin.codin.domain.post.domain.comment.dto.response.CommentResponseDTO;
@@ -39,6 +40,7 @@ public class CommentService {
     private final UserRepository userRepository;
     private final LikeService likeService;
     private final ReplyCommentService replyCommentService;
+    private final NotificationService notificationService;
     private final RedisService redisService;
     private final S3Service s3Service;
 
@@ -64,6 +66,7 @@ public class CommentService {
         redisService.applyBestScore(1, postId);
         postRepository.save(post);
         log.info("댓글 추가완료 postId: {}.", postId);
+        notificationService.sendNotificationMessageByComment(post.getUserId(), post.get_id().toString(), comment.getContent());
     }
 
     // 댓글 삭제 (Soft Delete)

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -66,7 +66,7 @@ public class CommentService {
         redisService.applyBestScore(1, postId);
         postRepository.save(post);
         log.info("댓글 추가완료 postId: {}.", postId);
-        notificationService.sendNotificationMessageByComment(post.getUserId(), post.get_id().toString(), comment.getContent());
+        if (userId != post.getUserId()) notificationService.sendNotificationMessageByComment(post.getPostCategory(), post.getUserId(), post.get_id().toString(), comment.getContent());
     }
 
     // 댓글 삭제 (Soft Delete)

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -4,6 +4,7 @@ import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.common.security.util.SecurityUtils;
 import inu.codin.codin.domain.like.entity.LikeType;
 import inu.codin.codin.domain.like.service.LikeService;
+import inu.codin.codin.domain.notification.service.NotificationService;
 import inu.codin.codin.domain.post.domain.comment.dto.response.CommentResponseDTO;
 import inu.codin.codin.domain.post.domain.comment.entity.CommentEntity;
 import inu.codin.codin.domain.post.domain.comment.repository.CommentRepository;
@@ -39,14 +40,12 @@ public class ReplyCommentService {
     private final UserRepository userRepository;
 
     private final LikeService likeService;
+    private final NotificationService notificationService;
     private final RedisService redisService;
     private final S3Service s3Service;
 
     // 대댓글 추가
     public void addReply(String id, ReplyCreateRequestDTO requestDTO) {
-        log.info("대댓글 추가 요청 - commentId: {}, content: {}, anonymous: {}",
-                id, requestDTO.getContent(), requestDTO.isAnonymous());
-
         ObjectId commentId = new ObjectId(id);
         CommentEntity comment = commentRepository.findByIdAndNotDeleted(commentId)
                 .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
@@ -74,12 +73,11 @@ public class ReplyCommentService {
         log.info("대댓글 추가 완료 - replyId: {}, postId: {}, commentCount: {}",
                 reply.get_id(), post.get_id(), post.getCommentCount());
 
+        notificationService.sendNotificationMessageByReply(comment.getUserId(), post.get_id().toString(), reply.getContent());
     }
 
     // 대댓글 삭제 (Soft Delete)
     public void softDeleteReply(String replyId) {
-        log.info("대댓글 삭제 요청 - replyId: {}", replyId);
-
         ReplyCommentEntity reply = replyCommentRepository.findByIdAndNotDeleted(new ObjectId(replyId))
                 .orElseThrow(() -> new NotFoundException("대댓글을 찾을 수 없습니다."));
         SecurityUtils.validateUser(reply.getUserId());
@@ -146,7 +144,6 @@ public class ReplyCommentService {
 
 
     public void updateReply(String id, @Valid ReplyUpdateRequestDTO requestDTO) {
-        log.info("대댓글 수정 요청 - replyId: {}, newContent: {}", id, requestDTO.getContent());
 
         ObjectId replyId = new ObjectId(id);
         ReplyCommentEntity reply = replyCommentRepository.findByIdAndNotDeleted(replyId)

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -73,7 +73,7 @@ public class ReplyCommentService {
 
         log.info("대댓글 추가 완료 - replyId: {}, postId: {}, commentCount: {}",
                 reply.get_id(), post.get_id(), post.getCommentCount());
-        if (userId != comment.getUserId()) notificationService.sendNotificationMessageByReply(post.getPostCategory(), comment.getUserId(), post.get_id().toString(), reply.getContent());
+        if (!userId.equals(post.getUserId())) notificationService.sendNotificationMessageByReply(post.getPostCategory(), comment.getUserId(), post.get_id().toString(), reply.getContent());
     }
 
     // 대댓글 삭제 (Soft Delete)

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -13,6 +13,7 @@ import inu.codin.codin.domain.post.domain.reply.dto.request.ReplyUpdateRequestDT
 import inu.codin.codin.domain.post.domain.reply.entity.ReplyCommentEntity;
 import inu.codin.codin.domain.post.domain.reply.repository.ReplyCommentRepository;
 import inu.codin.codin.domain.post.dto.response.UserDto;
+import inu.codin.codin.domain.post.entity.PostCategory;
 import inu.codin.codin.domain.post.entity.PostEntity;
 import inu.codin.codin.domain.post.repository.PostRepository;
 import inu.codin.codin.domain.user.entity.UserEntity;
@@ -72,8 +73,7 @@ public class ReplyCommentService {
 
         log.info("대댓글 추가 완료 - replyId: {}, postId: {}, commentCount: {}",
                 reply.get_id(), post.get_id(), post.getCommentCount());
-
-        notificationService.sendNotificationMessageByReply(comment.getUserId(), post.get_id().toString(), reply.getContent());
+        if (userId != comment.getUserId()) notificationService.sendNotificationMessageByReply(post.getPostCategory(), comment.getUserId(), post.get_id().toString(), reply.getContent());
     }
 
     // 대댓글 삭제 (Soft Delete)

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -13,7 +13,6 @@ import inu.codin.codin.domain.post.domain.reply.dto.request.ReplyUpdateRequestDT
 import inu.codin.codin.domain.post.domain.reply.entity.ReplyCommentEntity;
 import inu.codin.codin.domain.post.domain.reply.repository.ReplyCommentRepository;
 import inu.codin.codin.domain.post.dto.response.UserDto;
-import inu.codin.codin.domain.post.entity.PostCategory;
 import inu.codin.codin.domain.post.entity.PostEntity;
 import inu.codin.codin.domain.post.repository.PostRepository;
 import inu.codin.codin.domain.user.entity.UserEntity;

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -5,7 +5,6 @@ import inu.codin.codin.common.Department;
 import inu.codin.codin.domain.user.dto.request.UserNicknameRequestDto;
 import inu.codin.codin.common.security.dto.PortalLoginResponseDto;
 import inu.codin.codin.domain.notification.entity.NotificationPreference;
-import inu.codin.codin.domain.user.dto.request.UserUpdateRequestDto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -4,6 +4,8 @@ import inu.codin.codin.common.BaseTimeEntity;
 import inu.codin.codin.common.Department;
 import inu.codin.codin.domain.user.dto.request.UserNicknameRequestDto;
 import inu.codin.codin.common.security.dto.PortalLoginResponseDto;
+import inu.codin.codin.domain.notification.entity.NotificationPreference;
+import inu.codin.codin.domain.user.dto.request.UserUpdateRequestDto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,6 +41,8 @@ public class UserEntity extends BaseTimeEntity {
     private UserRole role;
 
     private UserStatus status;
+
+    private NotificationPreference notificationPreference = new NotificationPreference();
 
     @Builder
     public UserEntity(String email, String password, String studentId, String name, String nickname, String profileImageUrl, Department department, String college, Boolean undergraduate, UserRole role, UserStatus status) {

--- a/src/main/java/inu/codin/codin/infra/fcm/FcmConfig.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/FcmConfig.java
@@ -1,0 +1,34 @@
+package inu.codin.codin.infra.fcm;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class FcmConfig {
+
+    @Value("${google.firebase.key-path}")
+    private String fcmKeyPath;
+
+    @PostConstruct
+    public void init(){
+        try {
+            FileInputStream serviceAccount = new FileInputStream(fcmKeyPath);
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            FirebaseApp.initializeApp(options);
+            log.info("[init] FirebaseApp initialized");
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/controller/FcmController.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/controller/FcmController.java
@@ -1,0 +1,48 @@
+package inu.codin.codin.infra.fcm.controller;
+
+import inu.codin.codin.common.response.SingleResponse;
+import inu.codin.codin.infra.fcm.dto.FcmTokenRequest;
+import inu.codin.codin.infra.fcm.service.FcmService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/fcm")
+@Tag(name = "FCM API", description = "FCM 토큰 저장 API")
+@RequiredArgsConstructor
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @PostMapping("/save")
+    public ResponseEntity<?> sendFcmMessage(
+            @RequestBody @Valid FcmTokenRequest fcmTokenRequest
+    ) {
+        fcmService.saveFcmToken(fcmTokenRequest);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(new SingleResponse<>(202, "FCM 토큰 저장 성공", null));
+    }
+
+    @PostMapping("/subscribe")
+    public ResponseEntity<?> subscribeTopic(
+            @RequestBody String topic
+    ) {
+        fcmService.subscribeTopic(topic);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(new SingleResponse<>(202, "FCM 토픽 구독 성공", null));
+    }
+
+    @PostMapping("/unsubscribe")
+    public ResponseEntity<?> unsubscribeTopic(
+            @RequestBody String topic
+    ) {
+        fcmService.unsubscribeTopic(topic);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(new SingleResponse<>(202, "FCM 토픽 구독 해제 성공", null));
+    }
+
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/dto/FcmMessageTopicDto.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/dto/FcmMessageTopicDto.java
@@ -1,0 +1,29 @@
+package inu.codin.codin.infra.fcm.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * Fcm 메시지 DTO to Topic
+ * 서버 내부 로직에서 사용
+ */
+@Data
+public class FcmMessageTopicDto {
+
+    private String topic;
+    private String title;
+    private String body;
+    private String imageUrl;
+    private Map<String, String> data;
+
+    @Builder
+    public FcmMessageTopicDto(String topic, String title, String body, String imageUrl, Map<String, String> data) {
+        this.topic = topic;
+        this.title = title;
+        this.body = body;
+        this.imageUrl = imageUrl;
+        this.data = data;
+    }
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/dto/FcmMessageUserDto.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/dto/FcmMessageUserDto.java
@@ -1,0 +1,31 @@
+package inu.codin.codin.infra.fcm.dto;
+
+import inu.codin.codin.domain.user.entity.UserEntity;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Fcm 메시지 DTO to User
+ * 서버 내부 로직에서 사용
+ */
+@Data
+public class FcmMessageUserDto {
+
+    private UserEntity user;
+    private String title;
+    private String body;
+    private String imageUrl;
+    private Map<String, String> data;
+
+    @Builder
+    public FcmMessageUserDto(UserEntity user, String title, String body, String imageUrl, Map<String, String> data) {
+        this.user = user;
+        this.title = title;
+        this.body = body;
+        this.imageUrl = imageUrl;
+        this.data = data;
+    }
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/dto/FcmTokenRequest.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/dto/FcmTokenRequest.java
@@ -1,0 +1,20 @@
+package inu.codin.codin.infra.fcm.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class FcmTokenRequest {
+
+    @Schema(description = "Fcm Token")
+    @NotBlank
+    private String fcmToken;
+
+    @Schema(description = "Android, IOS")
+    @NotBlank
+    private String deviceType;
+
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/entity/FcmTokenEntity.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/entity/FcmTokenEntity.java
@@ -1,0 +1,57 @@
+package inu.codin.codin.infra.fcm.entity;
+
+import inu.codin.codin.common.BaseTimeEntity;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.infra.fcm.exception.FcmDuplicatedTokenException;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document(collection = "fcmToken")
+@Getter
+public class FcmTokenEntity extends BaseTimeEntity {
+
+    @Id
+    private ObjectId id;
+
+    @DBRef
+    private UserEntity user;
+
+    private List<String> fcmTokenList;
+
+    private String deviceType;
+
+    @Builder
+    public FcmTokenEntity(UserEntity user, List<String> fcmTokenList, String deviceType) {
+        this.user = user;
+        this.fcmTokenList = fcmTokenList;
+        this.deviceType = deviceType;
+    }
+
+    /**
+     * 유저의 FcmToken을 추가하는 메서드
+     */
+    public void addFcmToken(@NotBlank String fcmToken) {
+        checkDuplicatedFcmToken(fcmToken);
+        fcmTokenList.add(fcmToken);
+    }
+
+    /**
+     * fcmTokenList안에 중복되는지 확인하는 메서드
+     */
+    private void checkDuplicatedFcmToken(String fcmToken) {
+        if (fcmTokenList.contains(fcmToken)) {
+            throw new FcmDuplicatedTokenException("이미 등록된 FCM 토큰입니다.");
+        }
+    }
+
+    public void deleteFcmToken(String fcmToken) {
+        fcmTokenList.remove(fcmToken);
+    }
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/exception/FcmDuplicatedTokenException.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/exception/FcmDuplicatedTokenException.java
@@ -1,0 +1,7 @@
+package inu.codin.codin.infra.fcm.exception;
+
+public class FcmDuplicatedTokenException extends FcmException {
+    public FcmDuplicatedTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/exception/FcmException.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/exception/FcmException.java
@@ -1,0 +1,7 @@
+package inu.codin.codin.infra.fcm.exception;
+
+public class FcmException extends RuntimeException {
+    public FcmException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/exception/FcmTokenNotFoundException.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/exception/FcmTokenNotFoundException.java
@@ -1,0 +1,7 @@
+package inu.codin.codin.infra.fcm.exception;
+
+public class FcmTokenNotFoundException extends FcmException {
+    public FcmTokenNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/repository/FcmTokenRepository.java
@@ -1,0 +1,16 @@
+package inu.codin.codin.infra.fcm.repository;
+
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.infra.fcm.entity.FcmTokenEntity;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FcmTokenRepository extends MongoRepository<FcmTokenEntity, ObjectId> {
+    @Query("{ 'user': ?0, deletedAt: null }")
+    Optional<FcmTokenEntity> findByUser(UserEntity user);
+}

--- a/src/main/java/inu/codin/codin/infra/fcm/service/FcmService.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/service/FcmService.java
@@ -1,0 +1,208 @@
+package inu.codin.codin.infra.fcm.service;
+
+import com.google.firebase.messaging.*;
+import inu.codin.codin.common.exception.NotFoundException;
+import inu.codin.codin.common.security.util.SecurityUtils;
+import inu.codin.codin.domain.notification.entity.NotificationPreference;
+import inu.codin.codin.domain.user.entity.UserEntity;
+import inu.codin.codin.domain.user.repository.UserRepository;
+import inu.codin.codin.domain.user.service.UserService;
+import inu.codin.codin.infra.fcm.dto.FcmMessageTopicDto;
+import inu.codin.codin.infra.fcm.dto.FcmMessageUserDto;
+import inu.codin.codin.infra.fcm.dto.FcmTokenRequest;
+import inu.codin.codin.infra.fcm.entity.FcmTokenEntity;
+import inu.codin.codin.infra.fcm.exception.FcmTokenNotFoundException;
+import inu.codin.codin.infra.fcm.repository.FcmTokenRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 클라이언트로부터 받은 FCM 토큰을 저장하는 로직
+     * @param fcmTokenRequest FCM 토큰 요청 DTO
+     */
+    public void saveFcmToken(@Valid FcmTokenRequest fcmTokenRequest) {
+        // 유저의 FCM 토큰이 존재하는지 확인
+        ObjectId userId = SecurityUtils.getCurrentUserId();
+        UserEntity user = getUserEntityFromUserId(userId);
+        Optional<FcmTokenEntity> fcmToken = fcmTokenRepository.findByUser(user);
+
+        if (fcmToken.isPresent()) { // 이미 존재하는 유저라면 토큰 추가
+            FcmTokenEntity fcmTokenEntity = fcmToken.get();
+            fcmTokenEntity.addFcmToken(fcmTokenRequest.getFcmToken());
+            fcmTokenRepository.save(fcmTokenEntity);
+        }
+        else { // 존재하지 않는 FCM 토큰이라면 저장
+            FcmTokenEntity newFcmTokenEntity = FcmTokenEntity.builder()
+                    .user(user)
+                    .fcmTokenList(List.of(fcmTokenRequest.getFcmToken()))
+                    .deviceType(fcmTokenRequest.getDeviceType())
+                    .build();
+            fcmTokenRepository.save(newFcmTokenEntity);
+        }
+    }
+
+    /**
+     * FCM 메시지를 전송하는 로직 - 서버 내부 사용
+     * @param fcmMessageUserDto FCM 메시지 유저 DTO
+     */
+    public void sendFcmMessage(FcmMessageUserDto fcmMessageUserDto) {
+        // 유저의 알림 설정 조회
+        UserEntity user = fcmMessageUserDto.getUser();
+        NotificationPreference userPreference = fcmMessageUserDto.getUser().getNotificationPreference();
+
+        // 유저의 FCM 토큰 조회
+        FcmTokenEntity fcmTokenEntity = fcmTokenRepository.findByUser(user).orElseThrow(()
+                -> new FcmTokenNotFoundException("유저에게 FCM 토큰이 존재하지 않습니다."));
+
+        // 알림 설정에 따라 알림 전송
+        if (!userPreference.isAllowPush()) {
+            log.info("[sendFcmMessage] 알림 설정에서 푸시 알림을 허용하지 않았습니다. : {}", user.getEmail());
+            return;
+        }
+        for (String fcmToken : fcmTokenEntity.getFcmTokenList()) {
+            try {
+                Message message = Message.builder()
+                        .setNotification(Notification.builder()
+                                .setTitle(fcmMessageUserDto.getTitle())
+                                .setBody(fcmMessageUserDto.getBody())
+                                .setImage(fcmMessageUserDto.getImageUrl())
+                                .build())
+                        .setToken(fcmToken)
+                        .putAllData(fcmMessageUserDto.getData())
+                        .build();
+
+                String response = FirebaseMessaging.getInstance().send(message);
+                log.info("[sendFcmMessage] 알림 전송 성공 : {}", response);
+            } catch (FirebaseMessagingException e) {
+                log.error("[sendFcmMessage] 알림 전송 실패, errorCode : {}, msg : {}", e.getErrorCode(), e.getMessage());
+                handleFirebaseMessagingException(e, fcmTokenEntity, fcmToken);
+            }
+        }
+    }
+
+    // todo : FCM Bulk 메시지 전송 로직 추가
+    // todo : FCM 토칙 기반 메세지 전송 로직 추가 - 공지사항, 학과별 알림, 게시글 내 모든 댓글 인원에게 알림
+
+    /**
+     * FCM 메시지를 특정 토픽으로 전송하는 로직 - 서버 내부 로직
+     * 브로드 캐스팅 알림을 위해 사용
+     * @param fcmMessageTopicDto FCM 메시지 토픽 DTO
+     */
+    public void sendFcmMessageByTopic(FcmMessageTopicDto fcmMessageTopicDto) {
+        //
+        try {
+            Message message = Message.builder()
+                    .setNotification(Notification.builder()
+                            .setTitle(fcmMessageTopicDto.getTitle())
+                            .setBody(fcmMessageTopicDto.getBody())
+                            .setImage(fcmMessageTopicDto.getImageUrl())
+                            .build())
+                    .setTopic(fcmMessageTopicDto.getTopic())
+                    .putAllData(fcmMessageTopicDto.getData())
+                    .build();
+
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("[sendFcmMessageByTopic] 알림 전송 성공 : {}", response);
+        } catch (FirebaseMessagingException e) {
+            log.error("[sendFcmMessageByTopic] 알림 전송 실패, errorCode : {}, msg : {}", e.getErrorCode(), e.getMessage());
+        }
+    }
+
+    /**
+     * FCM 메시지 전송 중 발생한 예외를 처리하는 로직
+     * @param e FirebaseMessagingException
+     * @param fcmTokenEntity FcmTokenEntity
+     * @param fcmToken FCM 토큰
+     */
+    private void handleFirebaseMessagingException(FirebaseMessagingException e, FcmTokenEntity fcmTokenEntity, String fcmToken) {
+        MessagingErrorCode errorCode = e.getMessagingErrorCode();
+        switch (errorCode) {
+            case INVALID_ARGUMENT: // FCM 토큰이 유효하지 않을 때
+                log.error("Invalid argument error for token: {}", fcmToken);
+                break;
+            case UNREGISTERED: // FCM 토큰이 등록되지 않았을 때
+                log.warn("Unregistered token: {}. Removing from database.", fcmToken);
+                removeFcmToken(fcmTokenEntity, fcmToken);
+                break;
+            case QUOTA_EXCEEDED: // FCM 토큰의 전송량이 초과되었을 때
+                log.error("Quota exceeded for token: {}", fcmToken);
+                // 에러관리 및 리포팅 기능 추가
+                break;
+            case SENDER_ID_MISMATCH: // FCM 토큰의 발신자 ID가 일치하지 않을 때
+                log.error("Sender ID mismatch for token: {}", fcmToken);
+                break;
+            case THIRD_PARTY_AUTH_ERROR: // FCM 토큰의 인증이 실패했을 때
+                log.error("Third-party authentication error for token: {}", fcmToken);
+                break;
+            default: // 그 외의 에러
+                log.error("Unknown error for token: {}", fcmToken);
+                break;
+        }
+    }
+
+    // todo : FCM 토큰 만료시 삭제 로직 추가
+    private void removeFcmToken(FcmTokenEntity fcmTokenEntity, String fcmToken) {
+        fcmTokenEntity.deleteFcmToken(fcmToken);
+        fcmTokenRepository.save(fcmTokenEntity);
+    }
+
+    /**
+     * FCM 토픽 구독 로직
+     * @param topic 구독할 토픽 이름
+     */
+    public void subscribeTopic(String topic) {
+        ObjectId userId = SecurityUtils.getCurrentUserId();
+        UserEntity user = getUserEntityFromUserId(userId);
+        FcmTokenEntity fcmTokenEntity = fcmTokenRepository.findByUser(user)
+                .orElseThrow(() -> new FcmTokenNotFoundException("유저의 FCM 토큰이 존재하지 않습니다."));
+
+        for (String token : fcmTokenEntity.getFcmTokenList()) {
+            try {
+                FirebaseMessaging.getInstance().subscribeToTopic(List.of(token), topic);
+                log.info("FCM 토픽 구독 성공: 토픽={}, 토큰={}", topic, token);
+            } catch (FirebaseMessagingException e) {
+                log.error("FCM 토픽 구독 실패: 토픽={}, 토큰={}, 에러={}", topic, token, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * FCM 토픽 구독 해제 로직
+     * @param topic 구독 해제할 토픽 이름
+     */
+    public void unsubscribeTopic(String topic) {
+        ObjectId userId = SecurityUtils.getCurrentUserId();
+        UserEntity user = getUserEntityFromUserId(userId);
+        FcmTokenEntity fcmTokenEntity = fcmTokenRepository.findByUser(user)
+                .orElseThrow(() -> new FcmTokenNotFoundException("유저의 FCM 토큰이 존재하지 않습니다."));
+
+        for (String token : fcmTokenEntity.getFcmTokenList()) {
+            try {
+                FirebaseMessaging.getInstance().unsubscribeFromTopic(List.of(token), topic);
+                log.info("FCM 토픽 구독 해제 성공: 토픽={}, 토큰={}", topic, token);
+            } catch (FirebaseMessagingException e) {
+                log.error("FCM 토픽 구독 해제 실패: 토픽={}, 토큰={}, 에러={}", topic, token, e.getMessage());
+            }
+        }
+    }
+
+    public UserEntity getUserEntityFromUserId(ObjectId userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("해당 이메일에 대한 유저 정보를 찾을 수 없습니다."));
+    }
+
+}

--- a/src/main/java/inu/codin/codin/infra/redis/RedisStorageService.java
+++ b/src/main/java/inu/codin/codin/infra/redis/RedisStorageService.java
@@ -1,4 +1,4 @@
-package inu.codin.codin.common.security.service;
+package inu.codin.codin.infra.redis;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

우선은 fcm 토큰으로 알림을 보내는 로직은 설정했지만 동작은 X
현재 알림 내역 반환, 알림 읽기 기능만 존재

알림 내역
* 나의 게시글에 댓글 단 경우
* 나의 댓글에 대댓글을 단 경우
* 누군가가 새로운 채팅방을 생성한 경우

targetId란, 알림을 눌렀을 때 반환되는 게시글 또는 채팅방에 대한 _id 값

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/e2950a47-f0bc-46a3-8510-aa6be82a1374)

![image](https://github.com/user-attachments/assets/a28678ea-644e-48df-9bdd-fd4d286311cc)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
