### PR TITLE
fix :: 배포 환경에서 Fcm Path 읽지 못하는 오류 수정

### DIFF
--- a/src/main/java/inu/codin/codin/infra/fcm/FcmConfig.java
+++ b/src/main/java/inu/codin/codin/infra/fcm/FcmConfig.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 @Component
 @Slf4j
@@ -19,16 +20,21 @@ public class FcmConfig {
     private String fcmKeyPath;
 
     @PostConstruct
-    public void init(){
+    public void init() {
         try {
-            FileInputStream serviceAccount = new FileInputStream(fcmKeyPath);
+            InputStream serviceAccount = getClass().getClassLoader().getResourceAsStream(fcmKeyPath);
+
+            if (serviceAccount == null) {
+                throw new RuntimeException("Firebase config file not found in classpath.");
+            }
+
             FirebaseOptions options = new FirebaseOptions.Builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build();
             FirebaseApp.initializeApp(options);
             log.info("[init] FirebaseApp initialized");
         } catch (IOException e) {
-            throw new RuntimeException(e.getMessage());
+            throw new RuntimeException("Error initializing Firebase: " + e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

로컬에서 잘 작동하나 
배포 환경에서 fcmkeypath 를 제대로 읽지 못해 data/fcm/.json 파일을 읽지 못하는 문제 발생
-> fcmkeypath 상대경로를 ClassPath 로 변경
