### PR TITLE
fix : 로그인과 회원가입을 하나로 묶어 분기처리

### DIFF
--- a/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import inu.codin.codin.common.response.ExceptionResponse;
 import inu.codin.codin.common.security.exception.JwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -31,5 +32,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(new ExceptionResponse(e.getMessage(), HttpStatus.UNAUTHORIZED.value()));
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleValidationExceptions(MethodArgumentNotValidException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ExceptionResponse(e.getBindingResult().getFieldErrors().get(0).getDefaultMessage(), HttpStatus.UNAUTHORIZED.value()));    }
 
 }

--- a/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleValidationExceptions(MethodArgumentNotValidException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(new ExceptionResponse(e.getBindingResult().getFieldErrors().get(0).getDefaultMessage(), HttpStatus.UNAUTHORIZED.value()));    }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponse(e.getBindingResult().getFieldErrors().get(0).getDefaultMessage(), HttpStatus.BAD_REQUEST.value()));    }
 
 }

--- a/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
+++ b/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
@@ -11,12 +11,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,23 +23,37 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final AuthenticationManager authenticationManager;
     private final JwtService jwtService;
     private final AuthService authService;
 
-    @Operation(summary = "로그인")
-    @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody SignUpAndLoginRequestDto loginRequestDto, HttpServletResponse response) {
 
-        UsernamePasswordAuthenticationToken authenticationToken
-                = new UsernamePasswordAuthenticationToken(loginRequestDto.getStudentId(), loginRequestDto.getPassword());
+    @Operation(
+            summary = "포탈 로그인",
+            description = "포탈 아이디, 비밀번호를 통해 로그인 진행 및 학적 정보 반환"
+    )
+    @PostMapping("/portal")
+    public ResponseEntity<SingleResponse<?>> portalSignUp(@RequestBody @Valid SignUpAndLoginRequestDto signUpAndLoginRequestDto, HttpServletResponse response) {
+        Object result = authService.signUp(signUpAndLoginRequestDto, response);
+        if (result == null){
+            return ResponseEntity.ok()
+                    .body(new SingleResponse<>(200, "포탈 로그인 진행 완료", "로그인 완료"));
+        } else {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(new SingleResponse<>(201, "새로운 유저 등록 완료", result));
+        }
 
-        Authentication authentication = authenticationManager.authenticate(authenticationToken);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        jwtService.createToken(response);
+    }
 
-        return ResponseEntity.ok().body(new SingleResponse<>(200, "로그인 성공", null));
+    @Operation(summary = "회원가입")
+    @PostMapping(value = "/signup/{studentId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SingleResponse<?>> signUpUser(
+            @PathVariable("studentId") String studentId,
+            @RequestPart @Valid UserNicknameRequestDto userNicknameRequestDto,
+            @RequestPart(value = "userImage", required = false) MultipartFile userImage) {
+        authService.createUser(studentId, userNicknameRequestDto, userImage);
+        return ResponseEntity.ok()
+                .body(new SingleResponse<>(200, "회원가입 성공", null));
     }
 
     @Operation(summary = "로그아웃")
@@ -57,27 +68,5 @@ public class AuthController {
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
         jwtService.reissueToken(request, response);
         return ResponseEntity.ok().body(new SingleResponse<>(200, "토큰 재발급 성공", null));
-    }
-
-    @Operation(
-            summary = "포탈 로그인",
-            description = "포탈 아이디, 비밀번호를 통해 로그인 진행 및 학적 정보 반환"
-    )
-    @PostMapping("/portal")
-    public ResponseEntity<SingleResponse<?>> portalSignUp(@RequestBody @Valid SignUpAndLoginRequestDto signUpAndLoginRequestDto) throws Exception {
-        authService.signUp(signUpAndLoginRequestDto);
-        return ResponseEntity.ok()
-                .body(new SingleResponse<>(200, "포탈 로그인을 통한 학적 정보 반환 완료", null));
-    }
-
-    @Operation(summary = "회원가입")
-    @PostMapping(value = "/signup/{studentId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SingleResponse<?>> signUpUser(
-            @PathVariable("studentId") String studentId,
-            @RequestPart @Valid UserNicknameRequestDto userNicknameRequestDto,
-            @RequestPart(value = "userImage", required = false) MultipartFile userImage) {
-        authService.createUser(studentId, userNicknameRequestDto, userImage);
-        return ResponseEntity.ok()
-                .body(new SingleResponse<>(200, "회원가입 성공", null));
     }
 }

--- a/src/main/java/inu/codin/codin/common/security/dto/SignUpAndLoginRequestDto.java
+++ b/src/main/java/inu/codin/codin/common/security/dto/SignUpAndLoginRequestDto.java
@@ -1,6 +1,7 @@
 package inu.codin.codin.common.security.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,6 +10,7 @@ import lombok.Setter;
 public class SignUpAndLoginRequestDto {
 
     @NotBlank
+    @Size(min = 9 , max = 9 , message = "학번은 9자리여야 합니다.")
     private String studentId;
 
     @NotBlank

--- a/src/main/java/inu/codin/codin/common/security/service/AuthService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/AuthService.java
@@ -11,11 +11,16 @@ import inu.codin.codin.domain.user.entity.UserEntity;
 import inu.codin.codin.domain.user.exception.UserCreateFailException;
 import inu.codin.codin.domain.user.repository.UserRepository;
 import inu.codin.codin.infra.s3.S3Service;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,21 +38,38 @@ import static feign.Util.ISO_8859_1;
 @Slf4j
 public class AuthService {
 
+    private final AuthenticationManager authenticationManager;
     private final PortalClient portalClient;
     private final InuClient inuClient;
     private final UserRepository userRepository;
     private final S3Service s3Service;
+    private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
 
-    public void signUp(SignUpAndLoginRequestDto signUpAndLoginRequestDto) throws Exception {
-        //학번으로 회원가입 유무 판단
-        Optional<UserEntity> user = userRepository.findByStudentId(signUpAndLoginRequestDto.getStudentId());
-        if (user.isPresent()) throw new UserCreateFailException("이미 회원가입된 유저입니다.");
+    public Object signUp(SignUpAndLoginRequestDto signUpAndLoginRequestDto, HttpServletResponse response){
+        try {//학번으로 회원가입 유무 판단
+            Optional<UserEntity> user = userRepository.findByStudentId(signUpAndLoginRequestDto.getStudentId());
+            if (user.isPresent()) {
+                UsernamePasswordAuthenticationToken authenticationToken
+                        = new UsernamePasswordAuthenticationToken(signUpAndLoginRequestDto.getStudentId(), signUpAndLoginRequestDto.getPassword());
 
-        PortalLoginResponseDto userPortalLoginResponseDto
-                        = returnPortalInfo(signUpAndLoginRequestDto);
-        UserEntity userEntity = UserEntity.of(userPortalLoginResponseDto);
-        userRepository.save(userEntity);
+                Authentication authentication = authenticationManager.authenticate(authenticationToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                jwtService.createToken(response);
+                return null;
+            }
+
+            PortalLoginResponseDto userPortalLoginResponseDto
+                    = returnPortalInfo(signUpAndLoginRequestDto);
+            UserEntity userEntity = UserEntity.of(userPortalLoginResponseDto);
+            userRepository.save(userEntity);
+            return userEntity.get_id().toString();
+        } catch (Exception e) {
+            log.error("로그인 중 오류 발생", e);
+            throw new UserCreateFailException("아이디 혹은 비밀번호를 잘못 입력하였습니다.");
+        }
+
     }
 
     private PortalLoginResponseDto returnPortalInfo(SignUpAndLoginRequestDto signUpAndLoginRequestDto) throws Exception {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/user-attachments/assets/7b4c204b-2a6d-4f5c-bd64-aa64b52fa5d6)

해당 요청사항 해결

1. 처음 로그인한 유저라면?
![image](https://github.com/user-attachments/assets/6a9a4e29-eccb-48f4-974e-07dab7a973d6)
StatusCode : 201
헤더 토큰 발급 : X
response data : 회원가입된 유저의 _id(PK)

2. 존재하는 유저라면?
![image](https://github.com/user-attachments/assets/875c4a5e-fb0a-495e-ac72-272d33e56a3a)
StatusCode : 200
헤더 토큰 발급 : O
response data : null

3. 처음 로그인 하는 유저의 아이디 및 비밀번호 오류
![image](https://github.com/user-attachments/assets/0756513a-ebd5-4787-b227-cb2e91cc20f5)

백엔드 로그의 경우 
* 아이디 오류 : 포탈 서버로 보내는 POST 에러
![image](https://github.com/user-attachments/assets/73858c36-2216-4302-bb79-3f542d5e1af4)

* 비밀번호 오류 : 자격 증명 실패 에러
![image](https://github.com/user-attachments/assets/f1bef472-14fc-40ae-8840-06cfcbde84bb)

4. 학번 9자리 유효성 검사 및 에러 처리 추가
400 에러 (Bad Request) 반환
![image](https://github.com/user-attachments/assets/01e02bad-af39-4b71-b070-b9c9af560c24)


