### PR TITLE
[Feat : oauth2 기반 로그인] Redis 제거 → DB 기반 회원 등록 및 프로필 완료, Email 식별자 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ dependencies {
 	implementation 'org.jsoup:jsoup:1.15.3'
 	//json
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
+	//oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
+++ b/src/main/java/inu/codin/codin/common/security/controller/AuthController.java
@@ -14,8 +14,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping(value = "/auth")
@@ -26,33 +29,52 @@ public class AuthController {
     private final JwtService jwtService;
     private final AuthService authService;
 
-
-    @Operation(
-            summary = "포탈 로그인",
-            description = "포탈 아이디, 비밀번호를 통해 로그인 진행 및 학적 정보 반환"
-    )
-    @PostMapping("/portal")
-    public ResponseEntity<SingleResponse<?>> portalSignUp(@RequestBody @Valid SignUpAndLoginRequestDto signUpAndLoginRequestDto, HttpServletResponse response) {
-        Integer result = authService.signUp(signUpAndLoginRequestDto, response);
-        if (result.equals(0)) {
-            return ResponseEntity.ok()
-                    .body(new SingleResponse<>(200, "포탈 로그인 진행 완료", "기존 유저 로그인 완료"));
-        } else {
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(new SingleResponse<>(201, "포탈 로그인 진행 완료", "새로운 유저 등록 완료"));
-        }
-    }
-
-    @Operation(summary = "회원가입")
-    @PostMapping(value = "/signup/{studentId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SingleResponse<?>> signUpUser(
-            @PathVariable("studentId") String studentId,
-            @RequestPart @Valid UserNicknameRequestDto userNicknameRequestDto,
-            @RequestPart(value = "userImage", required = false) MultipartFile userImage) {
-        authService.createUser(studentId, userNicknameRequestDto, userImage);
+    @GetMapping("/google")
+    public ResponseEntity<SingleResponse<?>> googleLogin(HttpServletResponse response) throws IOException {
+        response.sendRedirect("/oauth2/authorization/google");
         return ResponseEntity.ok()
-                .body(new SingleResponse<>(200, "회원가입 성공", null));
+                .body(new SingleResponse<>(200, "google OAuth2 Login Redirect",null));
     }
+
+    @Operation(summary = "회원 정보 입력 마무리")
+    @PostMapping(value = "/signup/{email}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SingleResponse<?>> completeUserProfile(
+            @PathVariable("email") String email,
+            @RequestPart @Valid UserNicknameRequestDto userNicknameRequestDto,
+            @RequestPart(value = "userImage", required = false) MultipartFile userImage,
+            HttpServletResponse response) {
+        authService.completeUserProfile(email, userNicknameRequestDto, userImage, response);
+        return ResponseEntity.ok()
+                .body(new SingleResponse<>(200, "회원 정보 입력 마무리 성공", null));
+    }
+
+//
+//    @Operation(
+//            summary = "포탈 로그인",
+//            description = "포탈 아이디, 비밀번호를 통해 로그인 진행 및 학적 정보 반환"
+//    )
+//    @PostMapping("/portal")
+//    public ResponseEntity<SingleResponse<?>> portalSignUp(@RequestBody @Valid SignUpAndLoginRequestDto signUpAndLoginRequestDto, HttpServletResponse response) {
+//        Integer result = authService.signUp(signUpAndLoginRequestDto, response);
+//        if (result.equals(0)) {
+//            return ResponseEntity.ok()
+//                    .body(new SingleResponse<>(200, "포탈 로그인 진행 완료", "기존 유저 로그인 완료"));
+//        } else {
+//            return ResponseEntity.status(HttpStatus.CREATED)
+//                    .body(new SingleResponse<>(201, "포탈 로그인 진행 완료", "새로운 유저 등록 완료"));
+//        }
+//    }
+//
+//    @Operation(summary = "회원가입")
+//    @PostMapping(value = "/signup/{studentId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+//    public ResponseEntity<SingleResponse<?>> signUpUser(
+//            @PathVariable("studentId") String studentId,
+//            @RequestPart @Valid UserNicknameRequestDto userNicknameRequestDto,
+//            @RequestPart(value = "userImage", required = false) MultipartFile userImage) {
+//        authService.createUser(studentId, userNicknameRequestDto, userImage);
+//        return ResponseEntity.ok()
+//                .body(new SingleResponse<>(200, "회원가입 성공", null));
+//    }
 
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")

--- a/src/main/java/inu/codin/codin/common/security/enums/AuthResultStatus.java
+++ b/src/main/java/inu/codin/codin/common/security/enums/AuthResultStatus.java
@@ -1,0 +1,7 @@
+package inu.codin.codin.common.security.enums;
+
+public enum AuthResultStatus {
+    LOGIN_SUCCESS,          // 기존 회원이며, 프로필이 완료되어 정상 로그인
+    NEW_USER_REGISTERED,    // 신규 회원 등록 완료 (프로필 설정 미완료)
+    PROFILE_INCOMPLETE      // 기존 회원이지만 프로필 설정이 미완료됨
+}

--- a/src/main/java/inu/codin/codin/common/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/CustomOAuth2UserService.java
@@ -1,0 +1,43 @@
+package inu.codin.codin.common.security.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+/**
+ *  OAuth2 로그인 후 사용자 정보를 가로채고 이메일을 검증하는 로직
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // Get User Email
+        String email = oAuth2User.getAttribute("email");
+        log.info("email: {}", email);
+
+        // Only Allow @inu.ac.kr
+        if (email == null || !email.trim().endsWith("@inu.ac.kr")) {
+            OAuth2Error oauth2Error = new OAuth2Error(
+                    "invalid_email_domain",
+                    "허용되지 않은 이메일 도메인입니다. @inu.ac.kr 이어야합니다",
+                    null
+            );
+            throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.getDescription());
+        }
+
+        log.info("email2: {}", email);
+        return oAuth2User;
+    }
+}

--- a/src/main/java/inu/codin/codin/common/security/util/OAuth2LoginFailureHandler.java
+++ b/src/main/java/inu/codin/codin/common/security/util/OAuth2LoginFailureHandler.java
@@ -1,0 +1,37 @@
+package inu.codin.codin.common.security.util;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        String errorMessage = null;
+        if (exception instanceof OAuth2AuthenticationException) {
+            OAuth2Error error = ((OAuth2AuthenticationException) exception).getError();
+            errorMessage = error.getDescription();
+        }
+        if (errorMessage == null || errorMessage.isEmpty()) {
+            errorMessage = "인증 실패"; // 기본 오류 메시지
+        }
+
+        PrintWriter writer = response.getWriter();
+        writer.write("{\"code\":401, \"message\":\"" + errorMessage + "\"}");
+        writer.flush();
+    }
+}

--- a/src/main/java/inu/codin/codin/common/security/util/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/inu/codin/codin/common/security/util/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,54 @@
+package inu.codin.codin.common.security.util;
+
+import inu.codin.codin.common.security.enums.AuthResultStatus;
+import inu.codin.codin.common.security.jwt.JwtTokenProvider;
+import inu.codin.codin.common.security.service.AuthService;
+import inu.codin.codin.common.security.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final  AuthService authService;
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        // OAuth2 회원가입/로그인 처리 후 JWT 발급
+        AuthResultStatus result = authService.oauthLogin(oAuth2User, response);
+
+        response.setContentType("application/json;charset=UTF-8");
+        PrintWriter writer = response.getWriter();
+
+        // 상황에 따라 서로 다른 응답 메시지를 반환
+        switch (result) {
+            case LOGIN_SUCCESS:
+                writer.write("{\"code\":200, \"message\":\"정상 로그인 완료\"}");
+                break;
+            case NEW_USER_REGISTERED:
+                writer.write("{\"code\":201, \"message\":\"신규 회원 등록 완료. 프로필 설정이 필요합니다.\"}");
+                break;
+            case PROFILE_INCOMPLETE:
+                writer.write("{\"code\":200, \"message\":\"회원 프로필 설정 미완료. 프로필 설정 페이지로 이동해주세요.\"}");
+                break;
+            default:
+                writer.write("{\"code\":500, \"message\":\"알 수 없는 오류 발생\"}");
+                break;
+        }
+        writer.flush();
+
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -100,4 +100,10 @@ public class UserEntity extends BaseTimeEntity {
             this.status = UserStatus.ACTIVE;
         }
     }
+
+    public void disabledToactivateUser() {
+        if ( this.status == UserStatus.DISABLED) {
+            this.status = UserStatus.ACTIVE;
+        }
+    }
 }

--- a/src/main/java/inu/codin/codin/domain/user/repository/UserRepository.java
+++ b/src/main/java/inu/codin/codin/domain/user/repository/UserRepository.java
@@ -20,4 +20,7 @@ public interface UserRepository extends MongoRepository<UserEntity, ObjectId> {
     Optional<UserEntity> findByStudentId(String studentId);
 
     Optional<UserEntity> findByNicknameAndDeletedAtIsNull(String nickname);
+
+    @Query("{'email':  ?0, 'deletedAt': null, 'status':  { $in:  ['DISABLED'] }}")
+    Optional<UserEntity> findByEmailAndDisabled(String email);
 }

--- a/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetails.java
+++ b/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetails.java
@@ -77,7 +77,7 @@ public class CustomUserDetails implements UserDetails {
      */
     @Override
     public String getUsername() {
-        return studentId;
+        return email;
     }
 
     @Override

--- a/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetailsService.java
+++ b/src/main/java/inu/codin/codin/domain/user/security/CustomUserDetailsService.java
@@ -17,10 +17,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String studentId) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-        UserEntity user = userRepository.findByStudentId(studentId)
-                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없음, studentId :" + studentId));
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없음, email :" + email));
 
         if (!UserStatus.ACTIVE.equals(user.getStatus())) {
             throw new UserDisabledException("유저가 활성화되지 않았습니다");


### PR DESCRIPTION
## 📝 작업 내용

1. OAuth2 로그인 로직 개선 및 DB 기반 회원가입 프로세스 도입
- 기존 Redis를 통한 임시 저장 방식 대신, OAuth2 로그인 시 사용자 정보를 바로 DB에 저장하도록 변경하였습니다.
- 신규 OAuth2 사용자는 로그인 시 DB에 등록될 때, 프로필 미완료 상태로 userStatus를 DISABLED로 설정합니다.
- 이후 프론트엔드에서 닉네임 및 프로필 이미지 입력을 받는 프로필 설정 API를 통해 사용자 정보를 업데이트하고, userStatus를 ACTIVE로 전환합니다.

2. 로그인 처리 및 토큰 발급 변경
- 기존 회원 로그인 및 신규 회원 등록 로직에서, 기존에는 studentId를 식별자로 사용했으나, 소셜 로그인 환경에 맞게 email을 식별자로 사용하도록 전환하였습니다
- JWT 토큰 생성 시, authentication.getName() 값(학번 -> 이메일)을 토큰의 subject로 설정하고, 이를 기반으로 사용자 정보를 조회합니다.
- 사용자 상태에 따라 서로 다른 응답 메시지를 반환합니다.
         - 정상 로그인 (LOGIN_SUCCESS): 프로필이 완성된 회원은 JWT 토큰을 발급합니다.
         - 신규 회원 등록 (NEW_USER_REGISTERED): 신규 등록 시 프로필 미완료 상태로 저장하며, 프론트엔드에 프로필 설정이 필요하다는 메시지를 반환합니다.
         - 프로필 미완료 (PROFILE_INCOMPLETE): 기존 회원이지만 프로필 설정이 완료되지 않은 경우, 토큰 발급 없이 프론트엔드에 프로필 설정이 필요하다는 메시지를 반환합니다.

3. OAuth2UserService 검증 로직
- 로그인 이메일의 도메인이 inu.ac.kr 이 아닌경우 처리 로직입니다.
- OAuth2UserService에서는 반환된 사용자 정보에서 email을 추출한 후, email이 null이거나 공백 제거 후 “@inu.ac.kr” 도메인으로 끝나지 않으면 OAuth2AuthenticationException을 던지도록 했습니닷.
- OAuth2LoginFailureHandler 를 통해, 해당 예외를 클라이언트에 JSON 응답으로 전달합니다.

4. API 엔드포인트 정리
- /auth/google: OAuth2 인증을 트리거하는 엔드포인트로, 구글 로그인 페이지로 리다이렉션합니다.
     - 스웨거 상에선 cors 문제로 url 복사후 빈탭에서 진행후 아래 이미지 처럼 토큰값 복사해서 사용하면됩니다.
- /auth/signup/{email}: 프로필 설정(닉네임 및 프로필 이미지 입력) API로, 프로필 설정 완료 후 JWT 토큰을 재발급하여 정식 회원(ACTIVE)로 전환합니다.

### 스크린샷 (선택)
![스크린샷 2025-02-21 오전 3 34 38](https://github.com/user-attachments/assets/5240a3dd-666e-4fff-bba7-3f17238d3d3d)

![스크린샷 2025-02-21 오전 3 33 32](https://github.com/user-attachments/assets/799d8ab2-1a24-4b0f-ade6-b90b6c6b647d)
![스크린샷 2025-02-21 오전 3 33 53](https://github.com/user-attachments/assets/86d00ec9-72ab-4c46-8f4a-e53485ec9b12)

![스크린샷 2025-02-21 오전 3 35 18](https://github.com/user-attachments/assets/50643c4b-55c8-4f4c-9ee6-73a2920a1c58)
-> Token 생성 X
![스크린샷 2025-02-21 오전 3 43 13](https://github.com/user-attachments/assets/759356e6-0428-4198-8601-3e5f55f9e2ed)

![스크린샷 2025-02-21 오전 3 44 17](https://github.com/user-attachments/assets/a96487f3-6480-41f9-8049-7b81ce0d763f)
![스크린샷 2025-02-21 오전 3 36 12](https://github.com/user-attachments/assets/c751c4b3-3c31-4400-8065-c8566552156d)
-> Token 생성


## 💬 리뷰 요구사항(선택)

1. 제 임의대로 로직을 변경을 좀했는데 괜찮은지 확인 부탁드립니다
2. 프론트를,, 잘몰라서 위처럼 반환해주면 괜찮은지, 메세지가 수정이 필요한지 검토 한번 부탁드립니다.
3. 서브모듈 local에 업데이트해서 서브모듈 커밋 포인터 변경해뒀습니다! 테스트가 안되면 말해주세요
