### PR TITLE
fix : HandshakeInterceptor을 통해 쿠키로 사용자 인증 후 stomp 접속

### DIFF
--- a/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
@@ -132,7 +132,8 @@ public class SecurityConfig {
             "/v3/api/test1",
             "/ws-stomp/**",
             "/chats/**",
-            "/login/oauth2/code/**"
+            "/login/oauth2/code/**",
+            "/chat/**"
     };
 
     // Swagger 접근 가능한 URL

--- a/src/main/java/inu/codin/codin/common/config/WebSocketConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/WebSocketConfig.java
@@ -1,6 +1,8 @@
 package inu.codin.codin.common.config;
 
-import inu.codin.codin.domain.chat.StompMessageProcessor;
+import inu.codin.codin.common.security.service.JwtService;
+import inu.codin.codin.common.stomp.HttpHandShakeInterceptor;
+import inu.codin.codin.common.stomp.StompMessageProcessor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -20,11 +22,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private String BASEURL;
 
     private final StompMessageProcessor stompMessageProcessor;
+    private final JwtService jwtService;
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp") //handshake endpoint
                 .setAllowedOriginPatterns("http://localhost:3000", "http://localhost:8080", BASEURL)
-                .withSockJS();
+                .withSockJS()
+                .setInterceptors(new HttpHandShakeInterceptor(jwtService));
     }
 
     @Override

--- a/src/main/java/inu/codin/codin/common/stomp/HttpHandShakeInterceptor.java
+++ b/src/main/java/inu/codin/codin/common/stomp/HttpHandShakeInterceptor.java
@@ -1,0 +1,47 @@
+package inu.codin.codin.common.stomp;
+
+import inu.codin.codin.common.security.exception.JwtException;
+import inu.codin.codin.common.security.exception.SecurityErrorCode;
+import inu.codin.codin.common.security.service.JwtService;
+import io.jsonwebtoken.MalformedJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class HttpHandShakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtService jwtService;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        if (request instanceof ServletServerHttpRequest){
+            ServletServerHttpRequest serverHttpRequest = (ServletServerHttpRequest) request;
+
+            try {
+                jwtService.setAuthentication(serverHttpRequest);
+            } catch (MessageDeliveryException e) {
+                throw new MessageDeliveryException("[Chatting] Jwt로 인한 메세지 전송 오류입니다.");
+            } catch (MalformedJwtException e) {
+                throw new MalformedJwtException("[Chatting] 비정상적인 jwt 토큰 입니다.");
+            } catch (Exception e) {
+                throw new JwtException(SecurityErrorCode.INVALID_TOKEN, "[Chatting] 인증되지 않은 jwt 토큰 입니다.");
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+    }
+
+
+}

--- a/src/main/java/inu/codin/codin/common/stomp/StompMessageProcessor.java
+++ b/src/main/java/inu/codin/codin/common/stomp/StompMessageProcessor.java
@@ -1,16 +1,12 @@
-package inu.codin.codin.domain.chat;
+package inu.codin.codin.common.stomp;
 
 import inu.codin.codin.common.exception.NotFoundException;
-import inu.codin.codin.common.security.exception.JwtException;
-import inu.codin.codin.common.security.exception.SecurityErrorCode;
-import inu.codin.codin.common.security.jwt.JwtTokenProvider;
 import inu.codin.codin.domain.chat.chatroom.entity.ChatRoom;
 import inu.codin.codin.domain.chat.chatroom.repository.ChatRoomRepository;
 import inu.codin.codin.domain.chat.chatting.service.ChattingService;
 import inu.codin.codin.domain.user.entity.UserEntity;
 import inu.codin.codin.domain.user.repository.UserRepository;
-import inu.codin.codin.domain.user.security.CustomUserDetailsService;
-import io.jsonwebtoken.MalformedJwtException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
@@ -22,8 +18,6 @@ import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
@@ -35,29 +29,27 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 public class StompMessageProcessor implements ChannelInterceptor {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final CustomUserDetailsService customUserDetailsService;
     private final ChattingService chattingService;
     private final Map<String, String> sessionStore = new ConcurrentHashMap<>();
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
-    private static final String BEARER_PREFIX="Bearer ";
+
+    private final HttpServletRequest request;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel messageChannel){
         StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-        handleMessage(headerAccessor);
+        handleMessage(headerAccessor, request);
         return message;
     }
 
-    public void handleMessage(StompHeaderAccessor headerAccessor){
+    public void handleMessage(StompHeaderAccessor headerAccessor, HttpServletRequest request){
         if (headerAccessor == null || headerAccessor.getCommand() == null){
             throw new MessageDeliveryException(HttpStatus.BAD_REQUEST.toString());
         }
 
         switch (headerAccessor.getCommand()){
             case CONNECT -> {
-                getTokenByHeader(headerAccessor);
                 connectSession(headerAccessor);
             }
             case SUBSCRIBE -> {
@@ -100,48 +92,24 @@ public class StompMessageProcessor implements ChannelInterceptor {
     }
 
     private Result getResult(StompHeaderAccessor headerAccessor) {
-        String studentId;
+        String email;
         if (headerAccessor.getUser() != null) {
-            studentId = headerAccessor.getUser().getName();
+            email = headerAccessor.getUser().getName();
         } else {
             throw new UsernameNotFoundException("헤더에서 유저를 찾을 수 없습니다.");
         }
         String chatroomId = sessionStore.get(headerAccessor.getSessionId());
         if (chatroomId == null || !ObjectId.isValid(chatroomId)) {
-            throw new IllegalArgumentException("올바른 chatRoomId가 아닙니다: " + chatroomId);
+            throw new IllegalArgumentException("세션에서 가져올 수 없거나, 올바른 chatRoomId가 아닙니다: " + chatroomId);
         }
         ChatRoom chatroom = chatRoomRepository.findById(new ObjectId(chatroomId))
                 .orElseThrow(() -> new NotFoundException("채팅방을 찾을 수 없습니다."));
-        UserEntity user = userRepository.findByStudentId(studentId)
+        UserEntity user = userRepository.findByEmailAndDisabledAndActive(email)
                 .orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
         Result result = new Result(chatroom, user);
         return result;
     }
 
     private record Result(ChatRoom chatroom, UserEntity user) {
-    }
-
-    private void getTokenByHeader(StompHeaderAccessor headerAccessor) {
-        // 헤더 토큰 얻기
-        String authorizationHeader = String.valueOf(headerAccessor.getNativeHeader("Authorization"));
-        if (authorizationHeader == null || authorizationHeader.equals("null")) {
-            throw new MalformedJwtException("[Chatting] JWT를 찾을 수 없습니다.");
-        }
-        String token = authorizationHeader.substring(BEARER_PREFIX.length());
-
-        // 토큰 인증
-        try {
-            if (jwtTokenProvider.validateAccessToken(token)) {
-                String studentId = jwtTokenProvider.getUsername(token);
-                UserDetails userDetails = customUserDetailsService.loadUserByUsername(studentId);
-                headerAccessor.setUser(new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
-            }
-        } catch (MessageDeliveryException e) {
-            throw new MessageDeliveryException("[Chatting] Jwt로 인한 메세지 전송 오류입니다.");
-        } catch (MalformedJwtException e) {
-            throw new MalformedJwtException("[Chatting] 비정상적인 jwt 토큰 입니다.");
-        } catch (Exception e) {
-            throw new JwtException(SecurityErrorCode.INVALID_TOKEN, "[Chatting] 인증되지 않은 jwt 토큰 입니다.");
-        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

헤더의 토큰을 cookie 로직으로 변경하면서, 채팅 과정에서 유저를 인증하던 로직도 변경하였음.

* 기존 로직
CONNECT 시에 헤더의 토큰으로 유저 검증

* 변경 로직
stomp를 위한 handshake 과정 이전에 거쳐가는 `HandshakeInterceptor`을 사용하여 cookie의 토큰을 통해 유저 검증


**유저 검증이 잘 되어 user-name에 email이 떠 있는 모습**
![image](https://github.com/user-attachments/assets/00747e13-8003-4ebf-bcbe-ee244441f70e)


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
