### PR TITLE
Feat/152 lecture python

### DIFF
--- a/.github/workflows/Deploy_EC2.yml
+++ b/.github/workflows/Deploy_EC2.yml
@@ -51,7 +51,7 @@ jobs:
               docker rm -f codin-backend || true
               docker pull ${{ secrets.DOCKERHUB_USERNAME }}/codin-backend:latest
               docker run -d --net codin-docker_default -p 8080:8080 --name codin-backend \
-                -v /opt/project/backend-data/post_data/:/opt/project/backend-data/post_data/ \
+                -v /opt/project/backend-data/:/opt/project/backend-data/ \
                 ${{ secrets.DOCKERHUB_USERNAME }}/codin-backend:latest              
               docker images -f "dangling=true" -q | xargs sudo docker rmi || true
               docker ps -a

--- a/src/main/java/inu/codin/codin/domain/lecture/controller/LectureUploadController.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/controller/LectureUploadController.java
@@ -1,0 +1,52 @@
+package inu.codin.codin.domain.lecture.controller;
+
+import inu.codin.codin.common.response.SingleResponse;
+import inu.codin.codin.domain.lecture.service.LectureUploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/upload")
+@RequiredArgsConstructor
+public class LectureUploadController {
+
+    private final LectureUploadService lectureUploadService;
+
+    @Operation(
+            summary = "새 학기의 강의 내역 업로드",
+            description = "강의 내역서(엑셀 파일) 이름을 '년도-학기'로 설정하여 업로드 ex) 24-1.xlsx, 24-2.xlsx"
+    )
+    @PostMapping(value = "/lectures", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_MANAGER')")
+    public ResponseEntity<SingleResponse<?>> uploadNewSemesterLectures(@RequestParam("excelFile") MultipartFile file) {
+        lectureUploadService.uploadNewSemesterLectures(file);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SingleResponse<>(201, file.getOriginalFilename()+"의 강의 내역 업로드", null));
+
+    }
+
+    @Operation(
+            summary = "강의실 현황 업데이트 (!! 꼭 '/lectures/upload_new' 이후에 실행할 것 !!)",
+            description = "!! 꼭 '/lectures/upload_new' 이후에 실행할 것 !!" +
+                    "<br> 강의 내역서(엑셀 파일) 이름을 '년도-학기'로 설정하여 업로드 ex) 24-1.xlsx, 24-2.xlsx"
+    )
+    @PostMapping(value = "/rooms", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_MANAGER')")
+    public ResponseEntity<?> uploadNewSemesterRooms(@RequestParam("excelFile") MultipartFile file) {
+        lectureUploadService.uploadNewSemesterRooms(file);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SingleResponse<>(201, file.getName()+"의 강의실 현황 업데이트", null));
+
+    }
+
+
+}

--- a/src/main/java/inu/codin/codin/domain/lecture/exception/LecturePythonException.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/exception/LecturePythonException.java
@@ -1,0 +1,7 @@
+package inu.codin.codin.domain.lecture.exception;
+
+public class LecturePythonException extends RuntimeException{
+    public LecturePythonException(String msg){
+        super(msg);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/lecture/service/LectureUploadService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/LectureUploadService.java
@@ -1,0 +1,83 @@
+package inu.codin.codin.domain.lecture.service;
+
+import inu.codin.codin.domain.lecture.exception.LecturePythonException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+@Service
+@Slf4j
+public class LectureUploadService {
+
+    @Value("${lecture.file.path}")
+    private String UPLOAD_DIR;
+
+    @Value("${lecture.python.path}")
+    private String PYTHON_DIR;
+
+    public void uploadNewSemesterRooms(MultipartFile file) {
+        try {
+            String pythonNm = "dayTimeOfRoom.py";
+            ProcessBuilder processBuilder = new ProcessBuilder(
+                    PYTHON_DIR, UPLOAD_DIR + pythonNm, UPLOAD_DIR+file.getOriginalFilename()
+            );
+            log.info(processBuilder.command().toString());
+            Process process = processBuilder.start();
+            int exitCode = process.waitFor();
+            String result = new String(process.getInputStream().readAllBytes());
+            log.info(result);
+            log.warn("[uploadNewSemesterRooms] Exited dayTimeOfRoom.py with error code" + exitCode);
+            if (exitCode == 0)
+                log.info("[uploadNewSemesterRooms] {} 강의실 현황 업데이트 완료", file.getName());
+            else {
+                log.error("[uploadNewSemesterRooms] {} 강의실 현황 업데이트 실패", file.getOriginalFilename());
+                throw new LecturePythonException("강의실 현황 업데이트 실패, Python errorCode : " + exitCode);
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error(e.getMessage(), e.getStackTrace()[0]);
+            throw new LecturePythonException(e.getMessage());
+        }
+    }
+
+    public void uploadNewSemesterLectures(MultipartFile file){
+        try {
+            saveFile(file);
+
+            String pythonNm = "infoOfLecture.py";
+            ProcessBuilder processBuilder = new ProcessBuilder(
+                    PYTHON_DIR, UPLOAD_DIR + pythonNm, UPLOAD_DIR+file.getOriginalFilename()
+            );
+            log.info(processBuilder.command().toString());
+            Process process = processBuilder.start();
+
+            String result = new String(process.getInputStream().readAllBytes());
+            log.info(result);
+            int exitCode = process.waitFor();
+            log.warn("[uploadNewSemesterLectures] Exited infoOfLecture.py with error code " + exitCode);
+            if (exitCode == 0)
+                log.info("[uploadNewSemesterLectures] {} 학기 강의 정보 업로드 완료", file.getName());
+            else {
+                log.error("[uploadNewSemesterLectures] {} 업로드 실패", file.getOriginalFilename());
+                throw new LecturePythonException("강의실 현황 업데이트 실패, Python errorCode : " + exitCode);
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error(e.getMessage(), e.getStackTrace()[0]);
+            throw new LecturePythonException(e.getMessage());
+        }
+    }
+
+    private void saveFile(MultipartFile file) {
+        File savedFile = new File(UPLOAD_DIR + file.getOriginalFilename());
+        try (FileOutputStream fos = new FileOutputStream(savedFile)) {
+            fos.write(file.getBytes());
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/inu/codin/codin/domain/post/schedular/PostsScheduler.java
+++ b/src/main/java/inu/codin/codin/domain/post/schedular/PostsScheduler.java
@@ -20,14 +20,19 @@ public class PostsScheduler {
     @Value("${schedule.path}")
     private String PATH;
 
+    @Value("${lecture.python.path}")
+    private String PYTHON_DIR;
+
     @Scheduled(cron = "${schedule.department.cron}", zone = "Asia/Seoul")
     @Async
     public void departmentPostsScheduler() {
         try {
             String fileName = "department.py";
-            ProcessBuilder processBuilder = new ProcessBuilder().inheritIO().command("/usr/bin/python3",PATH + fileName);
-            System.out.println(PATH);
-            System.out.println("Running command: " + processBuilder.command());
+            ProcessBuilder processBuilder =
+                    new ProcessBuilder().inheritIO().command(
+                            PYTHON_DIR,
+                            PATH + fileName
+                    );
             Process process = processBuilder.start();
             int exitCode = process.waitFor();
             log.warn("Exited department python with error code" + exitCode);
@@ -46,8 +51,11 @@ public class PostsScheduler {
     public void starinuPostsScheduler(){
         try {
             String fileName = "starinu.py";
-            ProcessBuilder processBuilder = new ProcessBuilder().inheritIO().command("/usr/bin/python3",
-                    PATH + fileName);
+            ProcessBuilder processBuilder =
+                    new ProcessBuilder().inheritIO().command(
+                            PYTHON_DIR,
+                            PATH + fileName
+                    );
             Process process = processBuilder.start();
             int exitCode = process.waitFor();
             log.warn("Exited starinu python with error code" + exitCode);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#152 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 강의 내역서 (.xlsx) 파일을 통해 강의 내역과 강의실 현황을 구성하는 python 파일을 api를 통해서 실행하도록 설정

## 사용법
1. 꼭 새 학기의 강의 내역서는 "년도-학기.xlsx" 파일로 만든다. ex) 24-1, 24-2, 25-1
2. 해당 강의 내역서를 첨부하여 api를 실행시킨다.
2-1. /upload/lectures 먼저 실행 !!
2-2. 해당 엑셀 파일이 저장되면서 강의 내역을 업로드하는 로직 실행
2-3. 이후에 /upload/rooms 실행 (저장된 엑셀파일을 가져다가 사용하기 때문)
2-4. 강의실 현황을 업로드 하는 로직 실행

## python 파일 설명
### infoOfLecture.py
1. 강의명+교수명으로 존재하는 강의인지 파악하고, 존재한다면 semester에 이번 학기만 추가
2. 만약 존재하지 않는 강의(처음으로 등장한 강의)라면 새로 추가

###dayTimeOfRoom
1. lecture_rooms 초기화
2. 강의실이 존재하지 않는 강의라면 room을 0으로 설정, 나머지는 강의실+수업 시간 업로드
 
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
