### PR TITLE
Perf/162 채팅방 나가기와 채팅 내역 반환

### DIFF
--- a/src/main/java/inu/codin/codin/common/stomp/StompMessageService.java
+++ b/src/main/java/inu/codin/codin/common/stomp/StompMessageService.java
@@ -12,12 +12,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
@@ -72,7 +74,9 @@ public class StompMessageService {
             throw new UsernameNotFoundException("헤더에서 유저를 찾을 수 없습니다.");
         }
         log.info(headerAccessor.toString());
-        String chatroomId = headerAccessor.getFirstNativeHeader("chatRoomId");
+        String chatroomId ="";
+        if (Objects.equals(headerAccessor.getCommand(), StompCommand.DISCONNECT)) sessionStore.get(headerAccessor.getSessionId());
+        else chatroomId = headerAccessor.getFirstNativeHeader("chatRoomId");
         if (chatroomId == null || !ObjectId.isValid(chatroomId)) {
             throw new IllegalArgumentException("세션에서 가져올 수 없거나, 올바른 chatRoomId가 아닙니다: " + chatroomId);
         }

--- a/src/main/java/inu/codin/codin/common/stomp/StompMessageService.java
+++ b/src/main/java/inu/codin/codin/common/stomp/StompMessageService.java
@@ -12,14 +12,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
@@ -74,9 +72,7 @@ public class StompMessageService {
             throw new UsernameNotFoundException("헤더에서 유저를 찾을 수 없습니다.");
         }
         log.info(headerAccessor.toString());
-        String chatroomId ="";
-        if (Objects.equals(headerAccessor.getCommand(), StompCommand.DISCONNECT)) sessionStore.get(headerAccessor.getSessionId());
-        else chatroomId = headerAccessor.getFirstNativeHeader("chatRoomId");
+        String chatroomId = headerAccessor.getFirstNativeHeader("chatRoomId");
         if (chatroomId == null || !ObjectId.isValid(chatroomId)) {
             throw new IllegalArgumentException("세션에서 가져올 수 없거나, 올바른 chatRoomId가 아닙니다: " + chatroomId);
         }

--- a/src/main/java/inu/codin/codin/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatroom/controller/ChatRoomController.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -34,12 +32,12 @@ public class ChatRoomController {
     }
 
     @Operation(
-            summary = "사용자가 포함된 모든 채팅방 리스트 반환"
+            summary = "사용자가 나가지 않은 채팅방 리스트 반환"
     )
     @GetMapping
-    public ResponseEntity<ListResponse<ChatRoomListResponseDto>> getAllChatRoomByUser(@AuthenticationPrincipal UserDetails userDetails){
+    public ResponseEntity<ListResponse<ChatRoomListResponseDto>> getAllChatRoomByUser(){
         return ResponseEntity.ok()
-                .body(new ListResponse<>(200, "채팅방 리스트 반환 완료", chatRoomService.getAllChatRoomByUser(userDetails)));
+                .body(new ListResponse<>(200, "채팅방 리스트 반환 완료", chatRoomService.getAllChatRoomByUser()));
     }
 
     @Operation(

--- a/src/main/java/inu/codin/codin/domain/chat/chatroom/entity/ParticipantInfo.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatroom/entity/ParticipantInfo.java
@@ -4,8 +4,6 @@ import inu.codin.codin.common.dto.BaseTimeEntity;
 import lombok.*;
 import org.bson.types.ObjectId;
 
-import java.time.LocalDateTime;
-
 @Getter
 @NoArgsConstructor
 public class ParticipantInfo extends BaseTimeEntity {
@@ -13,19 +11,14 @@ public class ParticipantInfo extends BaseTimeEntity {
     private ObjectId userId;
     private boolean isConnected = false;
     private int unreadMessage = 0;
-
-    private boolean isLeaved = false;
-    private LocalDateTime whenLeaved;
     private boolean notificationsEnabled = true;
 
     @Builder
-    public ParticipantInfo(ObjectId userId, boolean isConnected, int unreadMessage, boolean notificationsEnabled, boolean isLeaved, LocalDateTime whenLeaved) {
+    public ParticipantInfo(ObjectId userId, boolean isConnected, int unreadMessage, boolean notificationsEnabled) {
         this.userId = userId;
         this.isConnected = isConnected;
         this.unreadMessage = unreadMessage;
         this.notificationsEnabled = notificationsEnabled;
-        this.isLeaved = isLeaved;
-        this.whenLeaved = whenLeaved;
     }
 
     public void updateNotification() {
@@ -37,8 +30,6 @@ public class ParticipantInfo extends BaseTimeEntity {
                 .userId(userId)
                 .isConnected(false)
                 .unreadMessage(0)
-                .isLeaved(false)
-                .whenLeaved(null)
                 .notificationsEnabled(true)
                 .build();
     }
@@ -56,15 +47,6 @@ public class ParticipantInfo extends BaseTimeEntity {
         this.isConnected = false;
         this.unreadMessage = 0;
         setUpdatedAt();
-    }
-
-    public void leave(){
-        this.isLeaved = true;
-        this.whenLeaved = LocalDateTime.now();
-    }
-
-    public void remain(){
-        this.isLeaved = false;
     }
 
 }

--- a/src/main/java/inu/codin/codin/domain/chat/chatroom/entity/ParticipantInfo.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatroom/entity/ParticipantInfo.java
@@ -4,6 +4,8 @@ import inu.codin.codin.common.dto.BaseTimeEntity;
 import lombok.*;
 import org.bson.types.ObjectId;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class ParticipantInfo extends BaseTimeEntity {
@@ -11,14 +13,19 @@ public class ParticipantInfo extends BaseTimeEntity {
     private ObjectId userId;
     private boolean isConnected = false;
     private int unreadMessage = 0;
+
+    private boolean isLeaved = false;
+    private LocalDateTime whenLeaved;
     private boolean notificationsEnabled = true;
 
     @Builder
-    public ParticipantInfo(ObjectId userId, boolean isConnected, int unreadMessage, boolean notificationsEnabled) {
+    public ParticipantInfo(ObjectId userId, boolean isConnected, int unreadMessage, boolean notificationsEnabled, boolean isLeaved, LocalDateTime whenLeaved) {
         this.userId = userId;
         this.isConnected = isConnected;
         this.unreadMessage = unreadMessage;
         this.notificationsEnabled = notificationsEnabled;
+        this.isLeaved = isLeaved;
+        this.whenLeaved = whenLeaved;
     }
 
     public void updateNotification() {
@@ -30,6 +37,8 @@ public class ParticipantInfo extends BaseTimeEntity {
                 .userId(userId)
                 .isConnected(false)
                 .unreadMessage(0)
+                .isLeaved(false)
+                .whenLeaved(null)
                 .notificationsEnabled(true)
                 .build();
     }
@@ -47,6 +56,15 @@ public class ParticipantInfo extends BaseTimeEntity {
         this.isConnected = false;
         this.unreadMessage = 0;
         setUpdatedAt();
+    }
+
+    public void leave(){
+        this.isLeaved = true;
+        this.whenLeaved = LocalDateTime.now();
+    }
+
+    public void remain(){
+        this.isLeaved = false;
     }
 
 }

--- a/src/main/java/inu/codin/codin/domain/chat/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatroom/repository/ChatRoomRepository.java
@@ -13,6 +13,6 @@ public interface ChatRoomRepository extends MongoRepository<ChatRoom, String> {
     @Query("{ '_id': ?0, 'deletedAt': null }")
     Optional<ChatRoom> findById(ObjectId id);
 
-    @Query("{ 'participants.info.?0.userId': ?0, 'deletedAt': null }")
-    List<ChatRoom> findByParticipant(ObjectId userId);
+    @Query("{ 'participants.info.?0.userId': ?0, 'participants.info.?0.isLeaved': false, 'deletedAt': null }")
+    List<ChatRoom> findByParticipantIsNotLeavedAndDeletedIsNull(ObjectId userId);
 }

--- a/src/main/java/inu/codin/codin/domain/chat/chatting/repository/ChattingRepository.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatting/repository/ChattingRepository.java
@@ -5,6 +5,7 @@ import org.bson.types.ObjectId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChattingRepository extends MongoRepository<Chatting, String> {
@@ -12,4 +13,7 @@ public interface ChattingRepository extends MongoRepository<Chatting, String> {
     List<Chatting> findAllByChatRoomIdOrderByCreatedAtDesc(ObjectId chatRoomId);
 
     List<Chatting> findAllByChatRoomId(ObjectId id, Pageable pageable);
+
+    List<Chatting> findAllByChatRoomIdAndCreatedAtAfter(ObjectId id, LocalDateTime whenLeaved, Pageable pageable);
+
 }

--- a/src/main/java/inu/codin/codin/domain/chat/chatting/service/ChattingService.java
+++ b/src/main/java/inu/codin/codin/domain/chat/chatting/service/ChattingService.java
@@ -1,8 +1,8 @@
 package inu.codin.codin.domain.chat.chatting.service;
 
-import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.common.security.util.SecurityUtils;
 import inu.codin.codin.domain.chat.chatroom.entity.ChatRoom;
+import inu.codin.codin.domain.chat.chatroom.entity.ParticipantInfo;
 import inu.codin.codin.domain.chat.chatroom.exception.ChatRoomNotFoundException;
 import inu.codin.codin.domain.chat.chatroom.repository.ChatRoomRepository;
 import inu.codin.codin.domain.chat.chatroom.service.ChatRoomService;
@@ -26,6 +26,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -46,9 +47,8 @@ public class ChattingService {
                     log.warn("[채팅방 조회 실패] 채팅방 ID: {}를 찾을 수 없습니다.", id);
                     return new ChatRoomNotFoundException("채팅방을 찾을 수 없습니다.");
                 });
-
         ObjectId userId = ((CustomUserDetails) authentication.getPrincipal()).getId();
-        Integer countOfParticipating = chatRoomService.countOfParticipating(chatRoom.get_id());
+        Integer countOfParticipating = chatRoomService.countOfParticipating(chatRoom.get_id()); //접속해 있는 사람 수 빼기 (읽은 count)
         Chatting chatting = Chatting.of(chatRoom.get_id(), chattingRequestDto, userId,
                 chatRoom.getParticipants().getInfo().size()-countOfParticipating);
 
@@ -56,33 +56,54 @@ public class ChattingService {
 
         chattingRepository.save(chatting);
 
+        //상대가 채팅방을 나간 상태라면 다시 불러와서 채팅 시작
+        chatRoom.getParticipants().getInfo().values().stream()
+                .filter(info -> !info.getUserId().equals(userId) && info.isLeaved())
+                .forEach(ParticipantInfo::remain);
+        chatRoomRepository.save(chatRoom);
+
+        eventPublisher.publishEvent(new ChattingArrivedEvent(this, chatting));
+        //상대 유저가 접속하지 않은 상태라면 unread 개수 업데이트 및 마지막 대화 내용 업데이트
+
 //        //Receiver의 알림 체크 후, 메세지 전송
 //        for (Participants participant : chatRoom.getParticipants()){
 //            if (participant.getUserId() != userId && participant.isNotificationsEnabled()){
 //                notificationService.sendNotificationMessageByChat(participant.getUserId(), chattingRequestDto, chatRoom);
 //            }
 //        }
-        eventPublisher.publishEvent(new ChattingArrivedEvent(this, chatting));
+
 
         return ChattingResponseDto.of(chatting);
     }
 
     public ChattingAndUserIdResponseDto getAllMessage(String id, int page) {
-            log.info("[메시지 조회] 채팅방 ID: {}, 페이지: {}", id, page);
+        ObjectId userId = SecurityUtils.getCurrentUserId();
+        ChatRoom chatRoom = chatRoomRepository.findById(new ObjectId(id))
+                .orElseThrow(() -> {
+                    log.warn("[채팅방 조회 실패] 채팅방 ID: {}를 찾을 수 없습니다.", id);
+                    return new ChatRoomNotFoundException("채팅방을 찾을 수 없습니다.");
+                });
+        log.info("[메시지 조회] 채팅방 ID: {}, 페이지: {}", id, page);
 
-            Pageable pageable = PageRequest.of(page, 20, Sort.by("createdAt").descending());
-            chatRoomRepository.findById(new ObjectId(id))
-                    .orElseThrow(() -> {
-                        log.error("[채팅방 조회 실패] 채팅방 ID: {}를 찾을 수 없습니다.", id);
-                        return new ChatRoomNotFoundException("채팅방을 찾을 수 없습니다.");
-                    });
+        Pageable pageable = PageRequest.of(page, 20, Sort.by("createdAt").descending());
+        chatRoomRepository.findById(new ObjectId(id))
+                .orElseThrow(() -> {
+                    log.error("[채팅방 조회 실패] 채팅방 ID: {}를 찾을 수 없습니다.", id);
+                    return new ChatRoomNotFoundException("채팅방을 찾을 수 없습니다.");
+                });
 
-            List<ChattingResponseDto> chattingResponseDto = chattingRepository.findAllByChatRoomId(new ObjectId(id), pageable)
+        List<ChattingResponseDto> chattingResponseDto;
+        LocalDateTime whenLeaved = chatRoom.getParticipants().getInfo().get(userId).getWhenLeaved();
+        if (whenLeaved!= null) //나간 적이 있다면 그 이후의 채팅 내역만 반환
+            chattingResponseDto = chattingRepository.findAllByChatRoomIdAndCreatedAtAfter(new ObjectId(id), whenLeaved, pageable)
                     .stream().map(ChattingResponseDto::of).toList();
+        else chattingResponseDto = chattingRepository.findAllByChatRoomId(new ObjectId(id), pageable)
+                .stream().map(ChattingResponseDto::of).toList();
 
-            log.info("[메시지 조회 성공] 채팅방 ID: {}, 메시지 개수: {}", id, chattingResponseDto.size());
 
-            return new ChattingAndUserIdResponseDto(chattingResponseDto, SecurityUtils.getCurrentUserId().toString());
+        log.info("[메시지 조회 성공] 채팅방 ID: {}, 메시지 개수: {}", id, chattingResponseDto.size());
+
+        return new ChattingAndUserIdResponseDto(chattingResponseDto, SecurityUtils.getCurrentUserId().toString());
     }
 
     public List<String> sendImageMessage(List<MultipartFile> chatImages) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#162 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 채팅방 나가기
[필요 기능]
1대1 채팅 과정에서 채팅방을 나갔을 경우
* 채팅방을 나간 유저에게는 해당 채팅방이 보이지 않고, 상대방에게는 채팅방이 보인다.
* 상대방에게 해당 채팅방으로 다시 연락이 올 경우 다시 채팅방이 생성된다.
* 채팅방을 나갔던 유저 입장에서는 이전 대화 내역이 보이지 않고, 새롭게 연락이 온 대화부터 시작된다.
* 상대방은 이전 대화 내역 모두 볼 수 있다.
* 만약 둘 다 채팅방을 나간 상태라면 해당 채팅방은 softdelete 처리

[구현 기능]
1. chatroom entity에 isLeave, whenLeave 칼럼을 추가하여 채팅방 나가기 시에 `isLeave=true, whenLeave=(나간 시점)` 생성
2. 채팅을 진행했을 때, 상대방의 `isLeave==true`라면 다시 불러오도록 한다.
3. 불러온 유저에게는 whenLeave 이후의 대화내역만 반환한다.
4. 채팅방은 `isLeave==false`인 내역만 조회한다.
5. 채팅방을 나갔을 경우, 상대방도 나간 상태라면 해당 채팅방은 softdelete한다.

### 스크린샷 (선택)

**채팅**
둘 다 isConnect = true , isLeaved = false
![image](https://github.com/user-attachments/assets/57b76989-0b2f-49b7-a119-0e470f244505)

**채팅방을 나갓을 경우**
왼쪽 유저가 채팅방을 나간 상태 (isLeaved=true,whenLeaved 생성)
![image](https://github.com/user-attachments/assets/5380075b-c1d4-4a60-af28-e610dcecc2b7)

채팅방 내역에서 제외 (아무것도 안뜨는 상태)
![image](https://github.com/user-attachments/assets/72cd0e09-cd28-42f8-89a3-2bba67801b05)

**남아있는 유저가 채팅을 다시 시작**
 isLeaved = false로 변경되면서 unread 개수가 1로 업데이트
왼쪽 유저의 채팅방 내역에 다시 등장
![image](https://github.com/user-attachments/assets/24b54a93-cb55-4f7d-8099-127cb0c7cd58)

**채팅 내역 차이**
채팅을 나갔다 온 유저는 이후의 내역만 반환 , 남아있던 유저는 그 전 내역까지 반환
![image](https://github.com/user-attachments/assets/be6a7130-3895-44ef-acd9-4199782a6226)

**둘 다 채팅방을 나갔을 경우**
softdelete로 deleteAt 생성
![image](https://github.com/user-attachments/assets/d209a5a4-58b9-45d0-ad40-285ec0d65098)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

몇 가지 에러 잡아야 함
1. 채팅 나가기 한 번만
2. 하나의 게시글에서 같은 사람들끼리의 채팅은 하나만