### PR TITLE
Fix/authentication

### DIFF
--- a/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/SecurityConfig.java
@@ -64,6 +64,8 @@ public class SecurityConfig {
     private final ClientRegistrationRepository clientRegistrationRepository;
     private final CustomOAuth2AccessTokenResponseClient customOAuth2AccessTokenResponseClient;
 
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
     @Value("${server.domain}")
     private String BASEURL;
 
@@ -85,6 +87,10 @@ public class SecurityConfig {
                                 .requestMatchers(MANAGER_AUTH_PATHS).hasRole("MANAGER")
                                 .requestMatchers(USER_AUTH_PATHS).hasRole("USER")
                                 .anyRequest().hasRole("USER")
+                )
+                //Security 내부 인증 실패 처리 => access_token 없는 경우
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
                 //oauth2 로그인 설정 추가
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/inu/codin/codin/common/security/util/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/inu/codin/codin/common/security/util/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package inu.codin.codin.common.security.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inu.codin.codin.common.response.ExceptionResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException exception) throws IOException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        String errorMessage = "AUTHENTICATION_REQUIRED.";
+        if (exception instanceof OAuth2AuthenticationException oauth2Ex) {
+            OAuth2Error error = oauth2Ex.getError();
+            if (error != null && error.getDescription() != null) {
+                errorMessage = error.getDescription();
+            }
+        }
+
+        ExceptionResponse errorResponse = new ExceptionResponse(errorMessage, HttpServletResponse.SC_UNAUTHORIZED);
+        String responseBody = objectMapper.writeValueAsString(errorResponse);
+
+        log.error("[AuthenticationEntryPoint] {}", responseBody);
+        response.getWriter().write(responseBody);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#177 Feat/apple login

## 📝 작업 내용

기존 상황별 처리 전략 ::

1. JWT 검증실패 ( 꺠졋거나 만료된 경우)
-> JWTAuthenticationFilter -> thorw new JwtException ->ExceptionHandlerFilter 에서 catch 후 401 JSON 응답
참고 : 직접 던진 커스텀 예외 (JwtException, RuntimeException)는 ExceptionHandlerFilter에서 처리

2. OAuth2로그인 실패
-> AuthenticationFailureHandler

추가 처리 전략 ::

Authorization 가 아예 존재하지 않는 경우 ( 토큰 자체가 없음 ) JwtAuthenticationFilter -> 일 안함 패싱함!!!
- . SecurityContext 자체가 비어있음 
->  이후 인증이 필요한 API 접근 시도시 
-> Spring Security 내부의 ExceptionTranslationFilter가 AuthenticationException 발생
=> AuthenticationEntryPoint가 처리 (로그인 페이지 리디렉션 / cusotm을 통해 JSON 응답-401 )

그래서 왜 기본 홈 html 페이지를 리디렉션 했냐,,??
Spring Security가 애초에 form 로그인 기반으로 설계되었기 때문이라고 합니다. 그래서 인증 실패시 로그인 페이지로 리디렉션 했습니다.
근데 우리는 Rest API 기반의 서비스를 개발하니 이를 JSON 형식으로 변환해야하기에 AuthenticationEntryPoin를 오버라이드해서 Cusotm 구현을 해야합니다. 




1. access_token => 존재O / 적절X
<img width="1019" alt="스크린샷 2025-03-28 오전 12 30 56" src="https://github.com/user-attachments/assets/a066d55b-3e39-4a02-a25f-9ffb458a2fd9" />

2.a access_token => 존재O / 비어있음
<img width="1027" alt="스크린샷 2025-03-28 오전 12 31 21" src="https://github.com/user-attachments/assets/3644a670-7dc7-46c8-b3ff-c77309db6759" />

2.b access_token => 존재X (이름 잘못됨 포함)
<img width="1018" alt="스크린샷 2025-03-28 오전 12 32 53" src="https://github.com/user-attachments/assets/32971c74-817b-413e-bd6f-65d814015b75" />



## 💬 리뷰 요구사항(선택)

프론트측에 전달하겠습니다
