### PR TITLE
fix : 게시글 반환 시 자신의 게시글인지 확인하는 isMine 변수 추가

### DIFF
--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostDetailResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostDetailResponseDTO.java
@@ -3,7 +3,6 @@ package inu.codin.codin.domain.post.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import inu.codin.codin.domain.post.entity.PostCategory;
 import inu.codin.codin.domain.post.entity.PostEntity;
-import inu.codin.codin.domain.report.dto.ReportInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -91,11 +90,13 @@ public class PostDetailResponseDTO {
     public static class UserInfo {
         private final boolean isLike;
         private final boolean isScrap;
+        private final boolean isMine;
 
         @Builder
-        public UserInfo(boolean isLike, boolean isScrap) {
+        public UserInfo(boolean isLike, boolean isScrap, boolean isMine) {
             this.isLike = isLike;
             this.isScrap = isScrap;
+            this.isMine = isMine;
         }
     }
 

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -168,7 +168,7 @@ public class PostService {
 
         ObjectId userId = SecurityUtils.getCurrentUserId();
 
-        UserInfo userInfo = getUserInfoAboutPost(userId, post.get_id());
+        UserInfo userInfo = getUserInfoAboutPost(userId, post.getUserId(), post.get_id());
 
         // 투표 게시물 처리
         if (post.getPostCategory() == PostCategory.POLL) {
@@ -272,10 +272,11 @@ public class PostService {
         }
     }
 
-    public UserInfo getUserInfoAboutPost(ObjectId userId, ObjectId postId){
+    public UserInfo getUserInfoAboutPost(ObjectId currentUserId, ObjectId postUserId, ObjectId postId){
         return UserInfo.builder()
-                .isLike(likeService.isLiked(LikeType.POST, postId, userId))
-                .isScrap(scrapService.isPostScraped(postId, userId))
+                .isLike(likeService.isLiked(LikeType.POST, postId, currentUserId))
+                .isScrap(scrapService.isPostScraped(postId, currentUserId))
+                .isMine(postUserId.equals(currentUserId))
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

자기 자신의 게시글인지 확인하여, 본인 게시글에서만 설정이 다름 (채팅하기, 차단하기가 아닌 삭제하기 만 존재)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
