### PR TITLE
fix : 베스트 게시글 Scheduler 및 조회 시에 삭제된 게시글에 대해 확인 및 데이터 삭제

### DIFF
--- a/src/main/java/inu/codin/codin/domain/post/repository/PostRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/repository/PostRepository.java
@@ -38,4 +38,6 @@ public interface PostRepository extends MongoRepository<PostEntity, ObjectId> {
             +
             "{ 'title': { $regex: ?0, $options: 'i' }, 'userId': { $nin: ?1 }  } ] }")
     Page<PostEntity> findAllByKeywordAndDeletedAtIsNull(String keyword, List<ObjectId> blockedUsersId, PageRequest pageRequest);
+
+    boolean existsBy_idAndDeletedAtIsNull(ObjectId id);
 }

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -294,8 +294,12 @@ public class PostService {
         Map<String, Double> posts = redisBestService.getBests();
         List<PostEntity> bestPosts = posts.entrySet().stream()
                 .map(post -> postRepository.findByIdAndNotDeleted(new ObjectId(post.getKey()))
-                        .orElseThrow(() -> new NotFoundException("해당 게시글을 찾을 수 없습니다."))
-                ).toList();
+                        .orElseGet(() -> {
+                            redisBestService.deleteBest(post.getKey());
+                            return null;
+                        }))
+                .filter(Objects::nonNull) // null 값 제거
+                .toList();
         log.info("Top 3 베스트 게시물 반환.");
         return getPostListResponseDtos(bestPosts);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

현재 게시글에 관심(좋아요, 스크랩, 댓글)이 반영될 때마다 시간대로 Cache에 저장하고 있는 과정

문제점 : Cache 데이터 중 베스트 게시글(post:top3)에서 게시글 삭제 시 반영 되고 있지 않은 오류
하지만 게시글을 삭제할 때마다 Cache에서 24시간 데이터를 찾거나 베스트 게시글에 포함되어 있는지 확인 후 삭제하는 것은 번거롭다고 판단

1. /posts/top3 , 베스트 게시글을 반환할 때 해당 게시글이 존재하는지 판단 후 없으면 Cache에서 삭제
2. Scheduler에서 1시간마다 베스트 게시글을 업데이트 할 때 시간대 데이터에서 삭제된 게시글인지 판단 후 삭제

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
