### PR TITLE
fix : GlobalException, ErrorCode interface 설정. ChatException 제작

### DIFF
--- a/src/main/java/inu/codin/codin/common/exception/GlobalErrorCode.java
+++ b/src/main/java/inu/codin/codin/common/exception/GlobalErrorCode.java
@@ -1,0 +1,9 @@
+package inu.codin.codin.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface GlobalErrorCode {
+    HttpStatus httpStatus();
+
+    String message();
+}

--- a/src/main/java/inu/codin/codin/common/exception/GlobalException.java
+++ b/src/main/java/inu/codin/codin/common/exception/GlobalException.java
@@ -1,0 +1,14 @@
+package inu.codin.codin.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException {
+
+    private final GlobalErrorCode errorCode;
+    public GlobalException(GlobalErrorCode errorCode){
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inu/codin/codin/common/exception/GlobalExceptionHandler.java
@@ -2,9 +2,7 @@ package inu.codin.codin.common.exception;
 
 import inu.codin.codin.common.response.ExceptionResponse;
 import inu.codin.codin.common.security.exception.JwtException;
-import inu.codin.codin.domain.chat.exception.ChatRoomErrorCode;
-import inu.codin.codin.domain.chat.exception.ChatRoomException;
-import inu.codin.codin.domain.chat.exception.ChatRoomExistedException;
+import inu.codin.codin.domain.chat.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.http.HttpStatus;
@@ -35,10 +33,17 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ExceptionResponse> handleChatRoomException(ChatRoomException e) {
         ChatRoomErrorCode code = e.getErrorCode();
         String message = code.message();
-        if (e instanceof ChatRoomExistedException existedException) //클라이언트 측에서 받아야 하는 chatroomId를 포함해서 전달
+        if (e instanceof ChatRoomExistedException existedException) //client 측에서 303 상태 코드 확인 후 message의 chatRoomId로 리다이렉션
             message = message + "/" + existedException.getChatRoomId();
         return ResponseEntity.status(code.httpStatus())
                 .body(new ExceptionResponse(message, code.httpStatus().value()));
+    }
+
+    @ExceptionHandler(ChattingException.class)
+    protected ResponseEntity<ExceptionResponse> handleChattingException(ChattingException e) {
+        ChattingErrorCode code = e.getErrorCode();
+        return ResponseEntity.status(code.httpStatus())
+                .body(new ExceptionResponse(code.message(), code.httpStatus().value()));
     }
 
     @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/inu/codin/codin/domain/chat/exception/ChatRoomErrorCode.java
+++ b/src/main/java/inu/codin/codin/domain/chat/exception/ChatRoomErrorCode.java
@@ -1,0 +1,26 @@
+package inu.codin.codin.domain.chat.exception;
+
+import inu.codin.codin.common.exception.GlobalErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ChatRoomErrorCode implements GlobalErrorCode {
+    CHATROOM_CREATE_MYSELF(HttpStatus.BAD_REQUEST, "자기 자신과는 채팅방을 생성할 수 없습니다."),
+    CHATROOM_EXISTED(HttpStatus.valueOf(303), "해당 reference에서 시작된 채팅방이 존재합니다."),
+    CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+    PARTICIPANTS_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 내의 참여자를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/chat/exception/ChatRoomException.java
+++ b/src/main/java/inu/codin/codin/domain/chat/exception/ChatRoomException.java
@@ -1,0 +1,14 @@
+package inu.codin.codin.domain.chat.exception;
+
+import inu.codin.codin.common.exception.GlobalException;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomException extends GlobalException {
+
+    private final ChatRoomErrorCode errorCode;
+    public ChatRoomException(ChatRoomErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/chat/exception/ChattingErrorCode.java
+++ b/src/main/java/inu/codin/codin/domain/chat/exception/ChattingErrorCode.java
@@ -1,11 +1,9 @@
 package inu.codin.codin.domain.chat.exception;
 
 import inu.codin.codin.common.exception.GlobalErrorCode;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-@Getter
 @RequiredArgsConstructor
 public enum ChattingErrorCode implements GlobalErrorCode {
 
@@ -18,11 +16,11 @@ public enum ChattingErrorCode implements GlobalErrorCode {
 
     @Override
     public HttpStatus httpStatus() {
-        return null;
+        return httpStatus;
     }
 
     @Override
     public String message() {
-        return null;
+        return message;
     }
 }

--- a/src/main/java/inu/codin/codin/domain/chat/exception/ChattingErrorCode.java
+++ b/src/main/java/inu/codin/codin/domain/chat/exception/ChattingErrorCode.java
@@ -1,0 +1,28 @@
+package inu.codin.codin.domain.chat.exception;
+
+import inu.codin.codin.common.exception.GlobalErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChattingErrorCode implements GlobalErrorCode {
+
+    CHATTING_USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "헤더에서 유저(email)을 찾을 수 없습니다."),
+    CHATTING_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "헤더에서 채팅방 _id를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return null;
+    }
+
+    @Override
+    public String message() {
+        return null;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/chat/exception/ChattingException.java
+++ b/src/main/java/inu/codin/codin/domain/chat/exception/ChattingException.java
@@ -1,0 +1,16 @@
+package inu.codin.codin.domain.chat.exception;
+
+import inu.codin.codin.common.exception.GlobalException;
+import lombok.Getter;
+
+@Getter
+public class ChattingException extends GlobalException {
+
+    private final ChattingErrorCode errorCode;
+    private final String sessionId;
+    public ChattingException(ChattingErrorCode errorCode, String sessionId) {
+        super(errorCode);
+        this.errorCode = errorCode;
+        this.sessionId = sessionId;
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

GlobalException과 GlobalErrorCode Interface를 제작하였습니다.
도메인마다 Exception을 제작할 때, GlobalException을 extends하여 제작하시면 되고,
Enum으로 ErrorCode를 제작할 때, GlobalErrorCode를 implements하여 제작하시면 됩니다.

```java
public class CustomException extends GlobalException { .. }

public enum CustomErrorCode implements GlobalErrorCode { .. }

```

아래 ChatRoom과 Chatting으로 만들어 놓았으니 참고하시면 좋을 거 같습니다.
그리고 GlobalExceptionHandler에서 해당 도메인 Exception을 넣어주시면 됩니다.
