### PR TITLE
refactor : Block 도메인 리팩토링 / 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/inu/codin/codin/common/util/ObjectIdUtil.java
+++ b/src/main/java/inu/codin/codin/common/util/ObjectIdUtil.java
@@ -1,0 +1,39 @@
+package inu.codin.codin.common.util;
+
+import org.bson.types.ObjectId;
+
+public class ObjectIdUtil {
+    private ObjectIdUtil() {}
+
+    /**
+     * String을 ObjectId로 변환
+     * @param objectIdString ObjectId 문자열
+     * @return ObjectId 객체
+     * @throws IllegalArgumentException 유효하지 않은 ObjectId 형식인 경우
+     */
+    public static ObjectId toObjectId(String objectIdString) {
+        try {
+            return new ObjectId(objectIdString);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 ObjectId 형식입니다: " + objectIdString, e);
+        }
+    }
+
+    /**
+     * ObjectId를 String으로 변환
+     * @param objectId ObjectId 객체
+     * @return ObjectId 문자열
+     */
+    public static String toString(ObjectId objectId) {
+        return objectId != null ? objectId.toHexString() : null;
+    }
+
+    /**
+     * ObjectId 유효성 검증
+     * @param objectIdString 검증할 문자열
+     * @return 유효한 ObjectId 형식이면 true
+     */
+    public static boolean isValid(String objectIdString) {
+        return ObjectId.isValid(objectIdString);
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/block/entity/BlockEntity.java
+++ b/src/main/java/inu/codin/codin/domain/block/entity/BlockEntity.java
@@ -1,25 +1,56 @@
 package inu.codin.codin.domain.block.entity;
 
 import inu.codin.codin.common.dto.BaseTimeEntity;
+import inu.codin.codin.common.exception.NotFoundException;
+import inu.codin.codin.domain.block.exception.AlreadyBlockedException;
 import lombok.Builder;
 import lombok.Getter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Getter
 @Document(collection = "blocks")
 public class BlockEntity extends BaseTimeEntity {
-    @Id
-    private ObjectId id;  // MongoDB의 기본 ID
 
-    private ObjectId blockingUserId;  // 차단한 사용자
-    private ObjectId blockedUserId;   // 차단된 사용자
+    @Id
+    private ObjectId id;
+
+    @Indexed
+    private ObjectId userId;
+
+    private List<ObjectId> blockedUsers = new ArrayList<>();
 
     @Builder
-    public BlockEntity(ObjectId blockingUserId, ObjectId blockedUserId) {
-        this.blockingUserId = blockingUserId;
-        this.blockedUserId = blockedUserId;
+    public BlockEntity(ObjectId userId, ObjectId blockedUser) {
+        this.userId = userId;
+        this.blockedUsers.add(blockedUser);
+    }
+
+    public static BlockEntity ofNew(ObjectId userId) {
+        return BlockEntity.builder()
+                .userId(userId)
+                .build();
+    }
+
+    public BlockEntity addBlockedUser(ObjectId blockedUser) {
+        if (this.blockedUsers.contains(blockedUser)) {
+            throw new AlreadyBlockedException("이미 차단한 유저입니다.");
+        }
+        this.blockedUsers.add(blockedUser);
+        return this;
+    }
+
+    public BlockEntity removeBockedUser(ObjectId blockedUser) {
+        if (this.blockedUsers.contains(blockedUser)) {
+            this.blockedUsers.remove(blockedUser);
+            return this;
+        }
+        throw new NotFoundException("차단 목록에 없는 유저입니다.");
     }
 }

--- a/src/main/java/inu/codin/codin/domain/block/repository/BlockRepository.java
+++ b/src/main/java/inu/codin/codin/domain/block/repository/BlockRepository.java
@@ -3,6 +3,7 @@ package inu.codin.codin.domain.block.repository;
 import inu.codin.codin.domain.block.entity.BlockEntity;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,10 +11,6 @@ import java.util.Optional;
 
 @Repository
 public interface BlockRepository extends MongoRepository<BlockEntity, ObjectId> {
-
-    boolean existsByBlockingUserIdAndBlockedUserId(ObjectId blockingUserId, ObjectId blockedUserId);
-    Optional<BlockEntity> findByBlockingUserIdAndBlockedUserId(ObjectId blockingUserId, ObjectId blockedUserId);
-
+    @Query("{'_id':  ?0, 'deletedAt': null}")
+    Optional<BlockEntity> findByUserId(ObjectId userId);
 }
-
-

--- a/src/main/java/inu/codin/codin/domain/block/service/BlockService.java
+++ b/src/main/java/inu/codin/codin/domain/block/service/BlockService.java
@@ -2,13 +2,11 @@ package inu.codin.codin.domain.block.service;
 
 import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.common.security.util.SecurityUtils;
+import inu.codin.codin.common.util.ObjectIdUtil;
 import inu.codin.codin.domain.block.entity.BlockEntity;
-import inu.codin.codin.domain.block.exception.AlreadyBlockedException;
-import inu.codin.codin.domain.block.exception.NotBlockedException;
 import inu.codin.codin.domain.block.exception.SelfBlockedException;
 import inu.codin.codin.domain.block.repository.BlockRepository;
-import inu.codin.codin.domain.user.entity.UserEntity;
-import inu.codin.codin.domain.user.repository.UserRepository;
+import inu.codin.codin.domain.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
@@ -19,70 +17,55 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BlockService {
     private final BlockRepository blockRepository;
-    private final UserRepository userRepository;
+    private final UserValidator userValidator;
 
+    /**
+     * 유저 차단
+     * SecurityContextHolder에서 현재 유저를 가져옴
+     * @param strBlockedUserId
+     */
     public void blockUser(String strBlockedUserId) {
-        ObjectId blockingUserId = SecurityUtils.getCurrentUserId();
-
-        if (blockingUserId.equals(new ObjectId(strBlockedUserId))){
-            throw new SelfBlockedException("자기 자신을 차단할 수 없습니다.");
-        }
-        // 유저 엔티티 조회
-        UserEntity user = userRepository.findById(blockingUserId)
-                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
-
-
-        ObjectId blockedUserId = new ObjectId(strBlockedUserId);
-        userRepository.findById(blockedUserId)
-                .orElseThrow(() -> new NotFoundException("차단할 사용자를 찾을 수 없습니다."));
-
-        // 중복 차단 방지
-        checkUserBlocked(blockingUserId,blockedUserId);
-
-
-        // 차단 정보 저
-        BlockEntity block = BlockEntity.builder()
-                .blockingUserId(blockingUserId)
-                .blockedUserId(blockedUserId)
-                .build();
-
-        blockRepository.save(block);
-
-        //유저 차단 리스트에 추가 ( 조회 필터링 목적)
-        user.getBlockedUsers().add(blockedUserId);
-        userRepository.save(user);
-    }
-
-    public void unblockUser(String strBlockedUserId) {
-        ObjectId blockingUserId = SecurityUtils.getCurrentUserId();
-        // 유저 엔티티 조회
-        UserEntity user = userRepository.findById(blockingUserId)
-                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
-
-        ObjectId blockedUserId = new ObjectId(strBlockedUserId);
-        // 차단 정보 조회
-        BlockEntity block = blockRepository.findByBlockingUserIdAndBlockedUserId(blockingUserId, blockedUserId)
-                .orElseThrow(() -> new NotBlockedException("차단되지 않은 사용자입니다."));
-
-        // 차단 해제
-        blockRepository.delete(block);
-
-
-        //유저 차단 리스트에서 삭제 ( 조회 필터링 목적)
-        user.getBlockedUsers().remove(blockedUserId);
-        userRepository.save(user);
-    }
-
-    public void checkUserBlocked(ObjectId blockingUserId, ObjectId blockedUserId) {
-        if (blockRepository.existsByBlockingUserIdAndBlockedUserId(blockingUserId, blockedUserId)) {
-            throw new AlreadyBlockedException("이미 상대방을 차단했습니다.");
-        }
-    }
-
-    public List<ObjectId> getBlockedUsers() {
         ObjectId userId = SecurityUtils.getCurrentUserId();
-        return userRepository.findById(userId)
-                .map(UserEntity::getBlockedUsers)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다."));
+        ObjectId blockedId = ObjectIdUtil.toObjectId(strBlockedUserId);
+
+        if (userId.equals(blockedId)) {
+            throw new SelfBlockedException("자신을 차단할 수 없습니다.");
+        }
+        userValidator.validateUserExists(userId, "차단하는 사용자를 찾을 수 없습니다.");
+        userValidator.validateUserExists(blockedId, "차단할 사용자를 찾을 수 없습니다.");
+
+        blockRepository.save(blockRepository.findByUserId(userId)
+                .orElseGet(() -> BlockEntity.ofNew(userId))
+                .addBlockedUser(blockedId));
+    }
+
+    /**
+     * 유저 차단해제
+     * SecurityContextHolder에서 현재 유저를 가져옴
+     * @param strBlockedUserId 차단 해제할 유저
+     */
+    public void unblockUser(String strBlockedUserId) {
+        ObjectId userId    = SecurityUtils.getCurrentUserId();
+        ObjectId blockedId = ObjectIdUtil.toObjectId(strBlockedUserId);
+
+        if (userId.equals(blockedId)) {
+            throw new SelfBlockedException("자신을 차단 해제할 수 없습니다.");
+        }
+        userValidator.validateUserExists(userId, "차단 해제하는 사용자를 찾을 수 없습니다.");
+        userValidator.validateUserExists(blockedId, "차단 해제할 사용자를 찾을 수 없습니다.");
+
+        blockRepository.save(blockRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException("차단 정보가 존재하지 않습니다."))
+                .removeBockedUser(blockedId));
+    }
+
+    /**
+     * 현재 유저의 차단된 유저 목록 반환
+     * @return 차단한 유저 목록 (빈 리스트가 제공될 수 있음)
+     */
+    public List<ObjectId> getBlockedUsers() {
+        return blockRepository.findByUserId(SecurityUtils.getCurrentUserId())
+                .map(BlockEntity::getBlockedUsers)
+                .orElse(List.of());
     }
 }

--- a/src/main/java/inu/codin/codin/domain/block/service/BlockService.java
+++ b/src/main/java/inu/codin/codin/domain/block/service/BlockService.java
@@ -6,7 +6,7 @@ import inu.codin.codin.common.util.ObjectIdUtil;
 import inu.codin.codin.domain.block.entity.BlockEntity;
 import inu.codin.codin.domain.block.exception.SelfBlockedException;
 import inu.codin.codin.domain.block.repository.BlockRepository;
-import inu.codin.codin.domain.user.validator.UserValidator;
+import inu.codin.codin.domain.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;

--- a/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -12,8 +12,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Document(collection = "users")
 @Getter
@@ -46,12 +44,10 @@ public class UserEntity extends BaseTimeEntity {
 
     private LocalDateTime totalSuspensionEndDate; //정지 게시물이 늘어날수록 정지 종료일이 중첩
 
-    private List<ObjectId> blockedUsers = new ArrayList<>();
-
     private NotificationPreference notificationPreference = new NotificationPreference();
 
     @Builder
-    public UserEntity(String email, String password, String studentId, String name, String nickname, String profileImageUrl, Department department, String college, Boolean undergraduate, UserRole role, UserStatus status, List<ObjectId> blockedUsers) {
+    public UserEntity(String email, String password, String studentId, String name, String nickname, String profileImageUrl, Department department, String college, Boolean undergraduate, UserRole role, UserStatus status) {
         this.email = email;
         this.password = password;
         this.studentId = studentId;
@@ -63,7 +59,6 @@ public class UserEntity extends BaseTimeEntity {
         this.undergraduate = undergraduate;
         this.role = role;
         this.status = status;
-        this.blockedUsers = (blockedUsers != null) ? blockedUsers : new ArrayList<>(); // ✅ 기본값 설정
     }
 
     public void updateNickname(String nickname) {
@@ -87,7 +82,6 @@ public class UserEntity extends BaseTimeEntity {
                 .profileImageUrl("")
                 .role(UserRole.USER)
                 .status(UserStatus.ACTIVE)
-                .blockedUsers(new ArrayList<>())
                 .build();
     }
 

--- a/src/main/java/inu/codin/codin/domain/user/service/UserValidator.java
+++ b/src/main/java/inu/codin/codin/domain/user/service/UserValidator.java
@@ -1,4 +1,4 @@
-package inu.codin.codin.domain.user.validator;
+package inu.codin.codin.domain.user.service;
 
 import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.domain.user.repository.UserRepository;
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class UserValidator {
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     /**
      * User 존재 여부 검증

--- a/src/main/java/inu/codin/codin/domain/user/validator/UserValidator.java
+++ b/src/main/java/inu/codin/codin/domain/user/validator/UserValidator.java
@@ -1,0 +1,23 @@
+package inu.codin.codin.domain.user.validator;
+
+import inu.codin.codin.common.exception.NotFoundException;
+import inu.codin.codin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserValidator {
+    private UserRepository userRepository;
+
+    /**
+     * User 존재 여부 검증
+     * @param userId 존재 검증할 userId - 삭제된 유저는 검색되지 않음
+     * @param exceptionMsg Exception 메세지
+     */
+    public void validateUserExists(ObjectId userId, String exceptionMsg) {
+        userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(exceptionMsg));
+    }
+}

--- a/src/test/java/inu/codin/codin/config/TestSecurityConfig.java
+++ b/src/test/java/inu/codin/codin/config/TestSecurityConfig.java
@@ -1,0 +1,26 @@
+package inu.codin.codin.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(org.springframework.security.config.http.SessionCreationPolicy.STATELESS)
+                );
+        return http.build();
+    }
+}

--- a/src/test/java/inu/codin/codin/domain/block/controller/BlockControllerTest.java
+++ b/src/test/java/inu/codin/codin/domain/block/controller/BlockControllerTest.java
@@ -1,0 +1,152 @@
+package inu.codin.codin.domain.block.controller;
+
+import inu.codin.codin.common.exception.NotFoundException;
+import inu.codin.codin.common.response.SingleResponse;
+import inu.codin.codin.domain.block.exception.AlreadyBlockedException;
+import inu.codin.codin.domain.block.exception.SelfBlockedException;
+import inu.codin.codin.domain.block.service.BlockService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BlockControllerTest {
+
+    @InjectMocks
+    private BlockController blockController;
+
+    @Mock
+    private BlockService blockService;
+
+    private final String testUserId = "686373fdaa87fd9618a63b49";
+    private final String blockedUserId = "6863740ceeb4a94ee959f592";
+
+    @Test
+    @DisplayName("사용자 차단 성공")
+    void blockUser_성공() {
+        //given
+        doNothing().when(blockService).blockUser(anyString());
+
+        //when
+        ResponseEntity<?> response = blockController.blockUser(blockedUserId);
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isInstanceOf(SingleResponse.class);
+        
+        SingleResponse<?> singleResponse = (SingleResponse<?>) response.getBody();
+        Assertions.assertNotNull(singleResponse);
+        assertThat(singleResponse.getCode()).isEqualTo(201);
+        assertThat(singleResponse.getMessage()).isEqualTo("사용자 차단 완료");
+        assertThat(singleResponse.getData()).isNull();
+
+        verify(blockService).blockUser(blockedUserId);
+    }
+
+    @Test
+    @DisplayName("사용자 차단 실패 - 자기 자신 차단")
+    void blockUser_실패_자기자신차단() {
+        //given
+        doThrow(new SelfBlockedException("자신을 차단할 수 없습니다."))
+                .when(blockService).blockUser(anyString());
+
+        //when & then
+        assertThatThrownBy(() -> blockController.blockUser(testUserId))
+                .isInstanceOf(SelfBlockedException.class)
+                .hasMessage("자신을 차단할 수 없습니다.");
+
+        verify(blockService).blockUser(testUserId);
+    }
+
+    @Test
+    @DisplayName("사용자 차단 실패 - 이미 차단된 사용자")
+    void blockUser_실패_이미차단된사용자() {
+        //given
+        doThrow(new AlreadyBlockedException("이미 차단한 유저입니다."))
+                .when(blockService).blockUser(anyString());
+
+        //when & then
+        assertThatThrownBy(() -> blockController.blockUser(blockedUserId))
+                .isInstanceOf(AlreadyBlockedException.class)
+                .hasMessage("이미 차단한 유저입니다.");
+
+        verify(blockService).blockUser(blockedUserId);
+    }
+
+    @Test
+    @DisplayName("사용자 차단 실패 - 차단할 사용자를 찾을 수 없음")
+    void blockUser_실패_사용자없음() {
+        //given
+        doThrow(new NotFoundException("차단할 사용자를 찾을 수 없습니다."))
+                .when(blockService).blockUser(anyString());
+
+        //when & then
+        assertThatThrownBy(() -> blockController.blockUser(blockedUserId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("차단할 사용자를 찾을 수 없습니다.");
+
+        verify(blockService).blockUser(blockedUserId);
+    }
+
+    @Test
+    @DisplayName("사용자 차단 해제 성공")
+    void unblockUser_성공() {
+        //given
+        doNothing().when(blockService).unblockUser(anyString());
+
+        //when
+        ResponseEntity<?> response = blockController.unblockUser(blockedUserId);
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isInstanceOf(SingleResponse.class);
+        
+        SingleResponse<?> singleResponse = (SingleResponse<?>) response.getBody();
+        assertThat(singleResponse.getCode()).isEqualTo(200);
+        assertThat(singleResponse.getMessage()).isEqualTo("사용자 차단 해제 완료");
+        assertThat(singleResponse.getData()).isNull();
+
+        verify(blockService).unblockUser(blockedUserId);
+    }
+
+    @Test
+    @DisplayName("사용자 차단 해제 실패 - 자기 자신 차단 해제")
+    void unblockUser_실패_자기자신차단해제() {
+        //given
+        doThrow(new SelfBlockedException("자신을 차단 해제할 수 없습니다."))
+                .when(blockService).unblockUser(anyString());
+
+        //when & then
+        assertThatThrownBy(() -> blockController.unblockUser(testUserId))
+                .isInstanceOf(SelfBlockedException.class)
+                .hasMessage("자신을 차단 해제할 수 없습니다.");
+
+        verify(blockService).unblockUser(testUserId);
+    }
+
+    @Test
+    @DisplayName("사용자 차단 해제 실패 - 차단 정보 없음")
+    void unblockUser_실패_차단정보없음() {
+        //given
+        doThrow(new NotFoundException("차단 정보가 존재하지 않습니다."))
+                .when(blockService).unblockUser(anyString());
+
+        //when & then
+        assertThatThrownBy(() -> blockController.unblockUser(blockedUserId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("차단 정보가 존재하지 않습니다.");
+
+        verify(blockService).unblockUser(blockedUserId);
+    }
+}

--- a/src/test/java/inu/codin/codin/domain/block/service/BlockServiceTest.java
+++ b/src/test/java/inu/codin/codin/domain/block/service/BlockServiceTest.java
@@ -1,0 +1,221 @@
+package inu.codin.codin.domain.block.service;
+
+import inu.codin.codin.common.exception.NotFoundException;
+import inu.codin.codin.common.security.util.SecurityUtils;
+import inu.codin.codin.common.util.ObjectIdUtil;
+import inu.codin.codin.domain.block.entity.BlockEntity;
+import inu.codin.codin.domain.block.exception.SelfBlockedException;
+import inu.codin.codin.domain.block.repository.BlockRepository;
+import inu.codin.codin.domain.user.service.UserValidator;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BlockServiceTest {
+
+    @InjectMocks
+    BlockService blockService;
+
+    @Mock
+    BlockRepository blockRepository;
+    @Mock
+    UserValidator userValidator;
+
+    private final ObjectId testUserId = ObjectIdUtil.toObjectId("686373fdaa87fd9618a63b49");
+    private final ObjectId blockedUserId = ObjectIdUtil.toObjectId("6863740ceeb4a94ee959f592");
+
+    @Test
+    @DisplayName("유저 차단 성공")
+    void blockUser_성공() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)){
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            BlockEntity existingBlock = BlockEntity.ofNew(testUserId);
+            when(blockRepository.findByUserId(testUserId)).thenReturn(Optional.of(existingBlock));
+            when(blockRepository.save(any(BlockEntity.class))).thenReturn(existingBlock);
+
+            //when
+            blockService.blockUser(blockedUserId.toString());
+
+            //then
+            verify(userValidator).validateUserExists(testUserId, "차단하는 사용자를 찾을 수 없습니다.");
+            verify(userValidator).validateUserExists(blockedUserId, "차단할 사용자를 찾을 수 없습니다.");
+            verify(blockRepository).save(any(BlockEntity.class));
+        }
+    }
+
+    @Test
+    @DisplayName("유저 차단 성공 - 새로운 BlockEntity 생성")
+    void blockUser_성공_새로운BlockEntity생성() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            when(blockRepository.findByUserId(testUserId)).thenReturn(Optional.empty());
+            when(blockRepository.save(any(BlockEntity.class))).thenReturn(BlockEntity.ofNew(testUserId));
+
+            //when
+            blockService.blockUser(blockedUserId.toString());
+
+            //then
+            verify(blockRepository).save(any(BlockEntity.class));
+        }
+    }
+
+    @Test
+    @DisplayName("유저 차단 실패 - 자기 자신 차단")
+    void blockUser_실패_자기자신차단() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            //when & then
+            assertThatThrownBy(() -> blockService.blockUser(testUserId.toString()))
+                    .isInstanceOf(SelfBlockedException.class)
+                    .hasMessage("자신을 차단할 수 없습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("유저 차단 실패 - 차단유저 존재하지 않음")
+    void blockUser_실패_차단유저X() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            doNothing().when(userValidator).validateUserExists(eq(testUserId), eq("차단하는 사용자를 찾을 수 없습니다."));
+            doThrow(new NotFoundException("차단할 사용자를 찾을 수 없습니다."))
+                    .when(userValidator).validateUserExists(any(ObjectId.class), eq("차단할 사용자를 찾을 수 없습니다."));
+
+            //when & then
+            assertThatThrownBy(() -> blockService.blockUser(blockedUserId.toString()))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("차단할 사용자를 찾을 수 없습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("유저 차단 실패 - 차단 실행 유저 존재하지 않음")
+    void blockUser_실패_차단실행유저X() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            doThrow(new NotFoundException("차단하는 사용자를 찾을 수 없습니다."))
+                    .when(userValidator).validateUserExists(eq(testUserId), eq("차단하는 사용자를 찾을 수 없습니다."));
+
+            //when & then
+            assertThatThrownBy(() -> blockService.blockUser(blockedUserId.toString()))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("차단하는 사용자를 찾을 수 없습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("유저 차단해제 성공")
+    void unblockUser_성공() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            BlockEntity existingBlock = BlockEntity.ofNew(testUserId);
+            existingBlock.addBlockedUser(blockedUserId);
+            when(blockRepository.findByUserId(testUserId)).thenReturn(Optional.of(existingBlock));
+            when(blockRepository.save(any(BlockEntity.class))).thenReturn(existingBlock);
+
+            //when
+            blockService.unblockUser(blockedUserId.toString());
+
+            //then
+            verify(userValidator).validateUserExists(testUserId, "차단 해제하는 사용자를 찾을 수 없습니다.");
+            verify(userValidator).validateUserExists(blockedUserId, "차단 해제할 사용자를 찾을 수 없습니다.");
+            verify(blockRepository).save(any(BlockEntity.class));
+        }
+    }
+
+    @Test
+    @DisplayName("유저 차단해제 실패 - 자기 자신 차단해제")
+    void unblockUser_실패_자기자신차단해제() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            //when & then
+            assertThatThrownBy(() -> blockService.unblockUser(testUserId.toString()))
+                    .isInstanceOf(SelfBlockedException.class)
+                    .hasMessage("자신을 차단 해제할 수 없습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("유저 차단해제 실패 - 차단 정보 없음")
+    void unblockUser_실패_차단정보없음() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            when(blockRepository.findByUserId(testUserId)).thenReturn(Optional.empty());
+
+            //when & then
+            assertThatThrownBy(() -> blockService.unblockUser(blockedUserId.toString()))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("차단 정보가 존재하지 않습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("차단된 유저 목록 조회 성공")
+    void getBlockedUsers_성공() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            BlockEntity blockEntity = spy(BlockEntity.ofNew(testUserId));
+            when(blockEntity.getBlockedUsers()).thenReturn(List.of(blockedUserId));
+            when(blockRepository.findByUserId(testUserId)).thenReturn(Optional.of(blockEntity));
+
+            //when
+            List<ObjectId> result = blockService.getBlockedUsers();
+
+            //then
+            assertThat(result).isNotNull()
+                    .hasSize(1)
+                    .doesNotContainNull()
+                    .contains(blockedUserId);
+            verify(blockRepository).findByUserId(testUserId);
+        }
+    }
+
+    @Test
+    @DisplayName("차단된 유저 목록 조회 - 차단 정보 없음")
+    void getBlockedUsers_차단정보없음() {
+        try (MockedStatic<SecurityUtils> mSecurityUtils = mockStatic(SecurityUtils.class)) {
+            //given
+            mSecurityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(testUserId);
+
+            when(blockRepository.findByUserId(testUserId)).thenReturn(Optional.empty());
+
+            //when
+            List<ObjectId> result = blockService.getBlockedUsers();
+
+            //then
+            assertThat(result).isEmpty();
+            verify(blockRepository).findByUserId(testUserId);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #214 

## 📝 작업 내용

> Block 도메인 리팩토링 및 테스트 작성

### 스크린샷

![스크린샷 2025-07-01 오후 5 01 42](https://github.com/user-attachments/assets/659c9812-b634-4f6f-a728-92944ab99cb5)

## 💬 리뷰 요구사항

현재 PR 이후에 #211 에서 적용된 내용을 바탕으로 수정하겠습니다.

또한, 추후에 User 도메인과 통합하면 좋을 것 같다는 생각이 들었습니다.