### PR TITLE
230 feat 외부에서 호출하는 lecture, review의 좋아요 반영

### DIFF
--- a/.github/workflows/Deploy_Main.yml
+++ b/.github/workflows/Deploy_Main.yml
@@ -58,6 +58,7 @@ jobs:
               docker pull ${{ secrets.DOCKERHUB_USERNAME }}/codin-backend:latest
               docker run -d --net codin-docker_default -p 8080:8080 --name codin-backend \
                 -v /opt/project/backend-data/:/opt/project/backend-data/ \
+                -e SPRING_PROFILES_ACTIVE=dev \
                 ${{ secrets.DOCKERHUB_USERNAME }}/codin-backend:latest              
               docker images -f "dangling=true" -q | xargs sudo docker rmi || true
               docker ps -a

--- a/src/main/java/inu/codin/codin/domain/lecture/domain/review/service/ReviewService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/domain/review/service/ReviewService.java
@@ -85,8 +85,8 @@ public class ReviewService {
         ObjectId userId = SecurityUtils.getCurrentUserId();
         return ReviewPageResponse.of(reviewPage.stream()
                         .map(review -> ReviewListResposneDto.of(review,
-                                likeService.isLiked(LikeType.REVIEW, review.get_id(), userId),
-                                likeService.getLikeCount(LikeType.REVIEW, review.get_id()))).toList(),
+                                likeService.isLiked(LikeType.REVIEW, review.get_id().toString(), userId),
+                                likeService.getLikeCount(LikeType.REVIEW, review.get_id().toString()))).toList(),
                 reviewPage.getTotalPages() -1,
                 reviewPage.hasNext()? reviewPage.getPageable().getPageNumber() + 1: -1);
     }

--- a/src/main/java/inu/codin/codin/domain/like/controller/LikeController.java
+++ b/src/main/java/inu/codin/codin/domain/like/controller/LikeController.java
@@ -22,7 +22,7 @@ public class LikeController {
 
     private final LikeService likeService;
 
-    @Operation(summary = "게시물, 댓글, 대댓글, 수강후기 좋아요 토글")
+    @Operation(summary = "게시물, 댓글, 대댓글, 수강후기, 과목 좋아요 토글")
     @PostMapping
     public ResponseEntity<SingleResponse<?>> toggleLike(@RequestBody @Valid LikeRequestDto likeRequestDto) {
         String message = likeService.toggleLike(likeRequestDto);

--- a/src/main/java/inu/codin/codin/domain/like/controller/LikeController.java
+++ b/src/main/java/inu/codin/codin/domain/like/controller/LikeController.java
@@ -2,17 +2,17 @@ package inu.codin.codin.domain.like.controller;
 
 import inu.codin.codin.common.response.SingleResponse;
 import inu.codin.codin.domain.like.dto.LikeRequestDto;
+import inu.codin.codin.domain.like.dto.LikeResponseType;
+import inu.codin.codin.domain.like.entity.LikeType;
 import inu.codin.codin.domain.like.service.LikeService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/likes")
@@ -22,12 +22,31 @@ public class LikeController {
 
     private final LikeService likeService;
 
-    @Operation(summary = "게시물, 댓글, 대댓글, 수강후기, 과목 좋아요 토글")
+    @Operation(summary = "POST(게시물), COMMENT(댓글), REPLY(대댓글) 좋아요 토글",
+            description = "LikeType = POST, COMMENT, REPLY, LECTURE, REVIEW <br>" +
+                    "id = 좋아요를 누를 entity의 pk <br> " +
+                    "외부 서버에서 LECTURE(과목), REVIEW(수강 후기) 좋아요 기능으로 사용")
     @PostMapping
     public ResponseEntity<SingleResponse<?>> toggleLike(@RequestBody @Valid LikeRequestDto likeRequestDto) {
-        String message = likeService.toggleLike(likeRequestDto);
+        LikeResponseType message = likeService.toggleLike(likeRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new SingleResponse<>(201, message, null));
+                .body(new SingleResponse<>(201, "좋아요가 " + message.getDescription() + "되었습니다.", message.toString()));
     }
+
+    @Hidden
+    @GetMapping
+    public Integer getLikeCount(@RequestParam("likeType") LikeType likeType,
+                                                          @RequestParam("id") String id) {
+        return likeService.getLikeCount(likeType, id);
+    }
+
+    @Hidden
+    @GetMapping("/user")
+    public Boolean isUserLiked(@RequestParam("likeType") LikeType likeType,
+                                                         @RequestParam("id") String id,
+                                                         @RequestParam("userId") String userId) {
+        return likeService.isLiked(likeType, id, userId);
+    }
+
 
 }

--- a/src/main/java/inu/codin/codin/domain/like/controller/LikeController.java
+++ b/src/main/java/inu/codin/codin/domain/like/controller/LikeController.java
@@ -3,6 +3,7 @@ package inu.codin.codin.domain.like.controller;
 import inu.codin.codin.common.response.SingleResponse;
 import inu.codin.codin.domain.like.dto.LikeRequestDto;
 import inu.codin.codin.domain.like.dto.LikeResponseType;
+import inu.codin.codin.domain.like.dto.LikedResponseDto;
 import inu.codin.codin.domain.like.entity.LikeType;
 import inu.codin.codin.domain.like.service.LikeService;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -13,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/likes")
@@ -48,5 +51,10 @@ public class LikeController {
         return likeService.isLiked(likeType, id, userId);
     }
 
-
+    @Hidden
+    @GetMapping("/list")
+    public List<LikedResponseDto> getLikedId(@RequestParam("likeType") LikeType likeType,
+                                             @RequestParam("userId") String userId) {
+        return likeService.getLikedId(likeType, userId);
+    }
 }

--- a/src/main/java/inu/codin/codin/domain/like/dto/LikeResponseType.java
+++ b/src/main/java/inu/codin/codin/domain/like/dto/LikeResponseType.java
@@ -1,0 +1,12 @@
+package inu.codin.codin.domain.like.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LikeResponseType {
+    ADD("추가"), RECOVER("복구"), REMOVE("삭제");
+
+    private final String description;
+}

--- a/src/main/java/inu/codin/codin/domain/like/dto/LikedResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/like/dto/LikedResponseDto.java
@@ -1,0 +1,8 @@
+package inu.codin.codin.domain.like.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LikedResponseDto {
+    private String likeTypeId;
+}

--- a/src/main/java/inu/codin/codin/domain/like/entity/LikeEntity.java
+++ b/src/main/java/inu/codin/codin/domain/like/entity/LikeEntity.java
@@ -12,12 +12,12 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class LikeEntity extends BaseTimeEntity {
     @Id
     private ObjectId _id;
-    private ObjectId likeTypeId; // 게시글, 댓글, 대댓글의 ID
+    private String likeTypeId; // 게시글, 댓글, 대댓글의 ID
     private LikeType likeType; // 엔티티 타입 (post, comment, reply)
     private ObjectId userId; // 좋아요를 누른 사용자 ID
 
     @Builder
-    public LikeEntity(ObjectId likeTypeId, LikeType likeType, ObjectId userId) {
+    public LikeEntity(String likeTypeId, LikeType likeType, ObjectId userId) {
         this.likeTypeId = likeTypeId;
         this.likeType = likeType;
         this.userId = userId;

--- a/src/main/java/inu/codin/codin/domain/like/entity/LikeType.java
+++ b/src/main/java/inu/codin/codin/domain/like/entity/LikeType.java
@@ -7,7 +7,8 @@ public enum LikeType {
     POST("게시물"),
     COMMENT("댓글"),
     REPLY("대댓글"),
-    REVIEW("수강 후기");
+    REVIEW("수강 후기"),
+    LECTURE("과목");
 
     private final String description;
 

--- a/src/main/java/inu/codin/codin/domain/like/exception/LikeCreateFailException.java
+++ b/src/main/java/inu/codin/codin/domain/like/exception/LikeCreateFailException.java
@@ -1,7 +1,0 @@
-package inu.codin.codin.domain.like.exception;
-
-public class LikeCreateFailException extends RuntimeException{
-    public LikeCreateFailException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/inu/codin/codin/domain/like/exception/LikeRemoveFailException.java
+++ b/src/main/java/inu/codin/codin/domain/like/exception/LikeRemoveFailException.java
@@ -1,7 +1,0 @@
-package inu.codin.codin.domain.like.exception;
-
-public class LikeRemoveFailException extends RuntimeException {
-    public LikeRemoveFailException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/inu/codin/codin/domain/like/repository/LikeRepository.java
+++ b/src/main/java/inu/codin/codin/domain/like/repository/LikeRepository.java
@@ -14,10 +14,8 @@ import java.util.Optional;
 
 public interface LikeRepository extends MongoRepository<LikeEntity, ObjectId> {
     // 특정 엔티티(게시글/댓글/대댓글)의 좋아요 개수 조회
-    int countByLikeTypeAndLikeTypeIdAndDeletedAtIsNull(LikeType likeType, ObjectId likeTypeId);
-    int countAllByLikeTypeAndLikeTypeIdAndDeletedAtIsNull(LikeType likeType, ObjectId likeTypeId);
-    boolean existsByLikeTypeAndLikeTypeIdAndUserIdAndDeletedAtIsNull(LikeType likeType, ObjectId id, ObjectId userId);
-
-    Optional<LikeEntity> findByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, ObjectId likeTypeId, ObjectId userId);
+    int countByLikeTypeAndLikeTypeIdAndDeletedAtIsNull(LikeType likeType, String likeTypeId);
+    boolean existsByLikeTypeAndLikeTypeIdAndUserIdAndDeletedAtIsNull(LikeType likeType, String id, ObjectId userId);
+    Optional<LikeEntity> findByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, String likeTypeId, ObjectId userId);
     Page<LikeEntity> findAllByUserIdAndLikeTypeAndDeletedAtIsNullOrderByCreatedAt(ObjectId userId, LikeType likeType, Pageable pageable);
 }

--- a/src/main/java/inu/codin/codin/domain/like/repository/LikeRepository.java
+++ b/src/main/java/inu/codin/codin/domain/like/repository/LikeRepository.java
@@ -1,13 +1,16 @@
 package inu.codin.codin.domain.like.repository;
 
+import inu.codin.codin.domain.like.dto.LikedResponseDto;
 import inu.codin.codin.domain.like.entity.LikeEntity;
 import inu.codin.codin.domain.like.entity.LikeType;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +21,7 @@ public interface LikeRepository extends MongoRepository<LikeEntity, ObjectId> {
     boolean existsByLikeTypeAndLikeTypeIdAndUserIdAndDeletedAtIsNull(LikeType likeType, String id, ObjectId userId);
     Optional<LikeEntity> findByLikeTypeAndLikeTypeIdAndUserId(LikeType likeType, String likeTypeId, ObjectId userId);
     Page<LikeEntity> findAllByUserIdAndLikeTypeAndDeletedAtIsNullOrderByCreatedAt(ObjectId userId, LikeType likeType, Pageable pageable);
+
+    @Query(value = "{ 'likeType': ?0, 'userId': ?1 }", fields = "{ 'likeTypeId': 1, '_id': 0 }")
+    List<LikedResponseDto> findLikeTypeIdByLikeTypeAndUserId(LikeType likeType, ObjectId userId);
 }

--- a/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
+++ b/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
@@ -139,9 +139,7 @@ public class LikeService {
 
     private void isEntityNotDeleted(LikeRequestDto likeRequestDto){
         LikeType likeType = likeRequestDto.getLikeType();
-        if (likeType.equals(LikeType.LECTURE) || likeType.equals(LikeType.REVIEW)){
-            String likeTypeId = likeRequestDto.getId();
-         } else {
+        if (likeType.equals(LikeType.POST) || likeType.equals(LikeType.REPLY) || likeType.equals(LikeType.COMMENT)) {
             ObjectId id = new ObjectId(likeRequestDto.getId());
             switch(likeType){
                 case POST -> postRepository.findByIdAndNotDeleted(id)
@@ -151,8 +149,12 @@ public class LikeService {
                 case COMMENT -> commentRepository.findByIdAndNotDeleted(id)
                         .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
             }
+        } //LECTURE, REVIEW는 외부 서버에서 사용하므로 삭제 여부 확인하지 않음
+        else if (likeType.equals(LikeType.LECTURE) || likeType.equals(LikeType.REVIEW)) {
+            return;
+        } else {
+            throw new NotFoundException("지원하지 않는 좋아요 타입입니다.");
         }
-
     }
 
     public List<LikedResponseDto> getLikedId(LikeType likeType, String userId) {

--- a/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
+++ b/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
@@ -4,6 +4,7 @@ import inu.codin.codin.common.exception.NotFoundException;
 import inu.codin.codin.common.security.util.SecurityUtils;
 import inu.codin.codin.domain.like.dto.LikeRequestDto;
 import inu.codin.codin.domain.like.dto.LikeResponseType;
+import inu.codin.codin.domain.like.dto.LikedResponseDto;
 import inu.codin.codin.domain.like.entity.LikeEntity;
 import inu.codin.codin.domain.like.entity.LikeType;
 import inu.codin.codin.domain.like.repository.LikeRepository;
@@ -19,6 +20,7 @@ import org.bson.types.ObjectId;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -153,5 +155,7 @@ public class LikeService {
 
     }
 
-
+    public List<LikedResponseDto> getLikedId(LikeType likeType, String userId) {
+        return likeRepository.findLikeTypeIdByLikeTypeAndUserId(likeType, new ObjectId(userId));
+    }
 }

--- a/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/comment/service/CommentService.java
@@ -123,7 +123,7 @@ public class CommentService {
                     }
                     return CommentResponseDTO.commentOf(comment, nickname, userImageUrl,
                             replyCommentService.getRepliesByCommentId(post.getAnonymous(), comment.get_id()),
-                            likeService.getLikeCount(LikeType.COMMENT, comment.get_id()),
+                            likeService.getLikeCount(LikeType.COMMENT, comment.get_id().toString()),
                             getUserInfoAboutComment(comment.get_id()));
                 })
                 .toList();
@@ -146,7 +146,7 @@ public class CommentService {
     public UserInfo getUserInfoAboutComment(ObjectId commentId) {
         ObjectId userId = SecurityUtils.getCurrentUserId();
         return UserInfo.builder()
-                .isLike(likeService.isLiked(LikeType.COMMENT, commentId, userId))
+                .isLike(likeService.isLiked(LikeType.COMMENT, commentId.toString(), userId))
                 .build();
     }
 

--- a/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/reply/service/ReplyCommentService.java
@@ -120,7 +120,7 @@ public class ReplyCommentService {
                         userImageUrl = reply.isAnonymous()? defaultImageUrl: userMap.get(reply.getUserId()).imageUrl();
                     }
                     return CommentResponseDTO.replyOf(reply, nickname, userImageUrl, List.of(),
-                            likeService.getLikeCount(LikeType.REPLY, reply.get_id()), // 대댓글 좋아요 수
+                            likeService.getLikeCount(LikeType.REPLY, reply.get_id().toString()), // 대댓글 좋아요 수
                             getUserInfoAboutReply(reply.get_id()));
                 }).toList();
     }
@@ -129,7 +129,7 @@ public class ReplyCommentService {
         ObjectId userId = SecurityUtils.getCurrentUserId();
         //log.info("대댓글 userInfo - replyId: {}, userId: {}", replyId, userId);
         return CommentResponseDTO.UserInfo.builder()
-                .isLike(likeService.isLiked(LikeType.REPLY, replyId, userId))
+                .isLike(likeService.isLiked(LikeType.REPLY, replyId.toString(), userId))
                 .build();
     }
 

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -161,7 +161,7 @@ public class PostService {
 
         //Post 관련 인자 처리
 
-        int likeCount = likeService.getLikeCount(LikeType.POST, post.get_id());
+        int likeCount = likeService.getLikeCount(LikeType.POST, post.get_id().toString());
         int scrapCount = scrapService.getScrapCount(post.get_id());
         int hitsCount = hitsService.getHitsCount(post.get_id());
         int commentCount = post.getCommentCount();
@@ -274,7 +274,7 @@ public class PostService {
 
     public UserInfo getUserInfoAboutPost(ObjectId currentUserId, ObjectId postUserId, ObjectId postId){
         return UserInfo.builder()
-                .isLike(likeService.isLiked(LikeType.POST, postId, currentUserId))
+                .isLike(likeService.isLiked(LikeType.POST, postId.toString(), currentUserId))
                 .isScrap(scrapService.isPostScraped(postId, currentUserId))
                 .isMine(postUserId.equals(currentUserId))
                 .build();

--- a/src/main/java/inu/codin/codin/domain/user/service/UserService.java
+++ b/src/main/java/inu/codin/codin/domain/user/service/UserService.java
@@ -77,7 +77,7 @@ public class UserService {
                 log.info("[좋아요 조회 시작] 유저 ID: {}, 타입: {}", userId, interactionType);
                 Page<LikeEntity> likePage = likeRepository.findAllByUserIdAndLikeTypeAndDeletedAtIsNullOrderByCreatedAt(userId, LikeType.valueOf("POST"), pageRequest);
                 List<PostEntity> postUserLike = likePage.getContent().stream()
-                        .map(likeEntity -> postRepository.findByIdAndNotDeleted(likeEntity.getLikeTypeId())
+                        .map(likeEntity -> postRepository.findByIdAndNotDeleted(new ObjectId(likeEntity.getLikeTypeId()))
                                 .orElseThrow(() -> new NotFoundException("유저가 좋아요를 누른 게시글을 찾을 수 없습니다.")))
                         .toList();
                 log.info("[좋아요 조회 완료] 총 페이지 수: {}, 다음 페이지 여부: {}", likePage.getTotalPages(), likePage.hasNext());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호
#230 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

새로 작업하게 된 Lecture 서버에서 필요한 좋아요 토글 기능을 위해 몇 가지 수정하였습니다.

1. mongodb에서의 entity id(ObjectId) 와 mysql에서의 entity id(Long)을 모두 허용하기 위해 String 형식으로 변경하였습니다.
2. 그에 따라서 POST, COMMENT, REPLY 와 LECTURE, REVIEW 부분이 조건문으로 분리된 부분이 생겼습니다.
3. 외부에서 호출하기 위한 api를 2개 생성하였습니다. (유저의 좋아요 여부, 엔티티의 좋아요 개수)
4. 좋아요 토글 기능에서 반환되었던 String message를 LikeResponseType enum으로 처리하여 반환될 수 있는 범위를 줄였습니다. 이에 따라서 외부에서 호출하는 서버에서도 동일하게 적용하였습니다.
 
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
