### PR TITLE
fix: 검색 결과에 삭제된 게시글이 표시되는 버그 수정 #247

### DIFF
--- a/src/main/java/inu/codin/codin/domain/post/repository/PostRepository.java
+++ b/src/main/java/inu/codin/codin/domain/post/repository/PostRepository.java
@@ -32,11 +32,17 @@ public interface PostRepository extends MongoRepository<PostEntity, ObjectId> {
 
 
 
-    @Query("{ '$or': [ "
-            +
-            "{ 'content': { $regex: ?0, $options: 'i' }, 'userId': { $nin: ?1 }  }, "
-            +
-            "{ 'title': { $regex: ?0, $options: 'i' }, 'userId': { $nin: ?1 }  } ] }")
+    @Query("""
+    { $and: [
+        { $or: [ { "deletedAt": null }, { "deletedAt": { $exists: false } } ] },
+        {'postStatus':  { $in:  ['ACTIVE'] }},
+        { "userId":  { $nin: ?1 } },
+        { $or: [
+                { "content": { $regex: ?0, $options: "i" } },
+                { "title":   { $regex: ?0, $options: "i" } }
+        ]}
+    ]}
+    """)
     Page<PostEntity> findAllByKeywordAndDeletedAtIsNull(String keyword, List<ObjectId> blockedUsersId, PageRequest pageRequest);
 
     boolean existsBy_idAndDeletedAtIsNull(ObjectId id);

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -132,6 +132,9 @@ public class PostService {
                 post.getPostCategory().toString().split("_")[0].equals("EXTRACURRICULAR")){
             log.error("비교과 게시글에 대한 권한이 없음. PostId: {}", post.get_id());
             throw new JwtException(SecurityErrorCode.ACCESS_DENIED, "비교과 게시글에 대한 권한이 없습니다.");
+        } else if (SecurityUtils.getCurrentUserRole().equals(UserRole.ADMIN) || SecurityUtils.getCurrentUserRole().equals(UserRole.MANAGER)) {
+            // 관리자 또는 어드민 계정은 게시글 권한을 가짐 (e.g. 삭제권한)
+            return;
         }
         SecurityUtils.validateUser(post.getUserId());
     }
@@ -283,6 +286,7 @@ public class PostService {
     public PostPageResponse searchPosts(String keyword, int pageNumber) {
         // 차단 목록 조회
         List<ObjectId> blockedUsersId = blockService.getBlockedUsers();
+        log.info("blockedUsersId: {}", blockedUsersId.size());
 
         PageRequest pageRequest = PageRequest.of(pageNumber, 20, Sort.by("createdAt").descending());
         Page<PostEntity> page = postRepository.findAllByKeywordAndDeletedAtIsNull(keyword, blockedUsersId, pageRequest);

--- a/src/main/java/inu/codin/codin/domain/post/service/PostService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostService.java
@@ -44,6 +44,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -288,9 +289,11 @@ public class PostService {
         List<ObjectId> blockedUsersId = blockService.getBlockedUsers();
         log.info("blockedUsersId: {}", blockedUsersId.size());
 
+        String pattern = Pattern.quote(keyword);
+
         PageRequest pageRequest = PageRequest.of(pageNumber, 20, Sort.by("createdAt").descending());
-        Page<PostEntity> page = postRepository.findAllByKeywordAndDeletedAtIsNull(keyword, blockedUsersId, pageRequest);
-        log.info("키워드 기반 게시물 검색: {}, Page: {}", keyword, pageNumber);
+        Page<PostEntity> page = postRepository.findAllByKeywordAndDeletedAtIsNull(pattern, blockedUsersId, pageRequest);
+        log.info("키워드 기반 게시물 검색: {}, Page: {}", pattern, pageNumber);
         return PostPageResponse.of(getPostListResponseDtos(page.getContent()), page.getTotalPages() - 1, page.hasNext() ? page.getPageable().getPageNumber() + 1 : -1);
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

close #247

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 쿼리문을 아래의 스크린샷과 같은 쿼리문으로 변경했습니다.
- 기존 쿼리문에서 soft delete 된 post에 대한 필터처리를 하고 있지 않았습니다.

관리자, 어드민 계정의 게시물 삭제권한 추가
- 원래 기존 비교과 과목이거나 혹은 본인의 게시물만 삭제가능했으나
- 로직에서 유저의 토큰으로부터 Role을 파악해서 삭제할수 있도록 조치했습니다.

### 스크린샷 (선택)

<img width="1087" height="291" alt="스크린샷 2025-09-05 00 03 45" src="https://github.com/user-attachments/assets/34895c64-c1cd-4fdf-b61e-d4ceaeacdcfc" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 게시물 검색이 더 정확해졌습니다: 삭제되었거나 비활성화된 게시물은 제외되고, 사용자가 차단한 작성자의 게시물도 결과에서 제외됩니다. 제목·내용에 대한 키워드 일치(대소문자 무시)로 보다 일관된 결과를 제공합니다.
  * 관리자·매니저 권한이 확장되었습니다: 게시물 소유자와 관계없이 게시물 관리(예: 삭제)가 가능합니다. 일반 사용자 권한은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->