### PR TITLE
perf: 캘린더 캐시 조회 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
 	//oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	//Cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/inu/codin/codin/common/config/CacheConfig.java
+++ b/src/main/java/inu/codin/codin/common/config/CacheConfig.java
@@ -1,0 +1,33 @@
+package inu.codin.codin.common.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(30));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+}

--- a/src/main/java/inu/codin/codin/domain/calendar/dto/CalendarDayResponse.java
+++ b/src/main/java/inu/codin/codin/domain/calendar/dto/CalendarDayResponse.java
@@ -1,6 +1,12 @@
 package inu.codin.codin.domain.calendar.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -12,6 +18,8 @@ public class CalendarDayResponse {
 
     @Schema(description = "날짜", example = "2025-08-23")
     @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
     private final LocalDate date;
 
     @Schema(description = "해당 날짜의 총 이벤트 수", example = "2")
@@ -20,7 +28,8 @@ public class CalendarDayResponse {
     @Schema(description = "해당 날짜의 이벤트 목록")
     private final List<EventDto> items;
 
-    public CalendarDayResponse(LocalDate date, int totalCont, List<EventDto> items) {
+    @JsonCreator
+    public CalendarDayResponse(@JsonProperty("date") LocalDate date, @JsonProperty("totalCont") int totalCont, @JsonProperty("items") List<EventDto> items) {
         this.date = date;
         this.totalCont = totalCont;
         this.items = items;

--- a/src/main/java/inu/codin/codin/domain/calendar/dto/CalendarMonthResponse.java
+++ b/src/main/java/inu/codin/codin/domain/calendar/dto/CalendarMonthResponse.java
@@ -1,5 +1,7 @@
 package inu.codin.codin.domain.calendar.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +21,8 @@ public class CalendarMonthResponse {
     private final List<CalendarDayResponse> days;
 
     @Builder
-    public CalendarMonthResponse(int year, int month, List<CalendarDayResponse> days) {
+    @JsonCreator
+    public CalendarMonthResponse(@JsonProperty("year") int year, @JsonProperty("month") int month, @JsonProperty("days") List<CalendarDayResponse> days) {
         this.year = year;
         this.month = month;
         this.days = days;

--- a/src/main/java/inu/codin/codin/domain/calendar/dto/EventDto.java
+++ b/src/main/java/inu/codin/codin/domain/calendar/dto/EventDto.java
@@ -1,5 +1,7 @@
 package inu.codin.codin.domain.calendar.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import inu.codin.codin.common.dto.Department;
 import inu.codin.codin.common.util.ObjectIdUtil;
 import inu.codin.codin.domain.calendar.entity.CalendarEntity;
@@ -20,7 +22,8 @@ public class EventDto {
     private final Department department;
 
     @Builder
-    public EventDto(String eventId, String content, Department department) {
+    @JsonCreator
+    public EventDto(@JsonProperty("eventId") String eventId, @JsonProperty("content") String content, @JsonProperty("department") Department department) {
         this.eventId = eventId;
         this.content = content;
         this.department = department;

--- a/src/main/java/inu/codin/codin/domain/calendar/service/CalendarService.java
+++ b/src/main/java/inu/codin/codin/domain/calendar/service/CalendarService.java
@@ -7,19 +7,37 @@ import inu.codin.codin.domain.calendar.exception.CalendarErrorCode;
 import inu.codin.codin.domain.calendar.exception.CalendarException;
 import inu.codin.codin.domain.calendar.repository.CalendarRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CalendarService {
 
     private final CalendarRepository calendarRepository;
 
+    private final String CACHE_NAME =  "calendar";
+    private final CacheManager cacheManager;
+
+    /**
+     * 캘린더 조회
+     * + 조회 캐시 Write-Through 전략 사용
+     * @param year 년도 ex) 2025
+     * @param month 월 ex) 8
+     * @return CalendarMonthResponse
+     */
+    @Cacheable(value = CACHE_NAME, key = "'month:' + T(java.time.YearMonth).of(#year, #month)")
     public CalendarMonthResponse getMonth(int year, int month) {
+        log.info("Getting month for year {} and month {}", year, month);
         if (month < 1 || month > 12) {
             throw new CalendarException(CalendarErrorCode.DATE_FORMAT_ERROR);
         }
@@ -61,6 +79,12 @@ public class CalendarService {
                 .build();
     }
 
+    /**
+     * 켈린더 이벤트 생성
+     * + 기존 엔티티의 시간을 기준으로 캐시를 무효화
+     * @param request CalendarCreateRequest
+     * @return CalendarCreateResponse
+     */
     public CalendarCreateResponse create(CalendarCreateRequest request) {
         if (request.getStartDate() == null || request.getEndDate() == null) {
             throw new CalendarException(CalendarErrorCode.DATE_CANNOT_NULL);
@@ -77,14 +101,46 @@ public class CalendarService {
                 .build();
 
         CalendarEntity savedEntity = calendarRepository.save(entity);
+        evictMonthBetween(savedEntity.getStartDate(), savedEntity.getEndDate());
+
         return CalendarCreateResponse.of(savedEntity);
     }
 
+    /**
+     * 켈린더 이벤트 삭제(SoftDelete)
+     * + 기존 엔티티의 시간을 기준으로 캐시를 무효화
+     * @param id
+     */
     public void delete(String id) {
         ObjectId objectId = ObjectIdUtil.toObjectId(id);
         CalendarEntity calendar = calendarRepository.findByIdAndNotDeleted(objectId)
                 .orElseThrow(() -> new CalendarException(CalendarErrorCode.CALENDAR_EVENT_NOT_FOUND));
+
         calendar.delete();
         calendarRepository.save(calendar);
+
+        LocalDate start = calendar.getStartDate();
+        LocalDate end = calendar.getEndDate();
+        evictMonthBetween(start, end);
+    }
+
+    /**
+     * 캐시 무효화
+     * @param startDate
+     * @param endDate
+     */
+    private void evictMonthBetween(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) return;
+        Cache cache = cacheManager.getCache(CACHE_NAME);
+        if (cache == null) return;
+
+        YearMonth from = YearMonth.from(startDate);
+        YearMonth to = YearMonth.from(endDate);
+
+        for (YearMonth ym = from; !ym.isAfter(to); ym = ym.plusMonths(1)) {
+            String key = "month:" + ym;
+            log.info("Evicting month {} from {} to {}", ym, from, to);
+            cache.evictIfPresent(key);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#253 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- spring-boot-starter-cache와 redis를 이용해 Calendar 부분에 캐시를 추가했습니다.

- Read 비율이 매우 높은 API이기 때문에 30분 TTL으로 구현
- CacheConfig를 생성해 캐시 설정 내용을 저장
- DB 데이터가 워낙 작기 때문에 유의미한 성능 향상은 스트레스 테스트에서 23퍼센트로 보였습니다.
  - Jmeter: 200스레드, Infitie로 부하 테스트 

### 스크린샷 (선택)

#### 캐싱 도입 이전

<img width="1558" height="73" alt="스크린샷 2025-09-05 17 16 26" src="https://github.com/user-attachments/assets/3df0de57-b56a-4f5a-b9a4-97131007e1d2" />
<img width="1533" height="865" alt="스크린샷 2025-09-05 17 16 16" src="https://github.com/user-attachments/assets/db665666-0d86-4337-8eb1-500566b20132" />
<img width="1531" height="861" alt="스크린샷 2025-09-05 17 16 21" src="https://github.com/user-attachments/assets/ccafbcb4-75c9-4b30-8948-5aeb58caa12d" />

#### 캐싱 도입 이후
<img width="1553" height="74" alt="스크린샷 2025-09-05 17 12 53" src="https://github.com/user-attachments/assets/55402267-8ef1-4519-b007-5b92c1b3f015" />
<img width="1532" height="866" alt="스크린샷 2025-09-05 17 12 46" src="https://github.com/user-attachments/assets/b8eceb66-bcb7-4d4b-9ad3-404cc061862c" />
<img width="1530" height="860" alt="스크린샷 2025-09-05 17 12 38" src="https://github.com/user-attachments/assets/c85f4351-959c-430a-bf80-a8a68b8dbeb1" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 캘린더 월별 조회 결과를 캐시하여 반복 요청 시 응답 속도를 크게 향상했습니다. 일정 생성/삭제 시 관련 월 캐시가 자동으로 갱신되며, 기본 캐시 유효기간은 30분입니다.
  - API 응답의 날짜와 캘린더 관련 DTO에 대한 JSON 직렬화/역직렬화 설정을 강화해 클라이언트와의 호환성과 데이터 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->