### PR TITLE
fix: login redirect issue 

### DIFF
--- a/src/main/java/inu/codin/codin/common/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/inu/codin/codin/common/security/filter/ExceptionHandlerFilter.java
@@ -31,8 +31,6 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (IllegalArgumentException e) {
-            log.warn("[doFilterInternal] IllegalArgumentException msg: {}", e.getMessage());
         } catch (Exception e) {
             log.warn("[doFilterInternal] Exception in ExceptionHandlerFilter: {}", e.getMessage());
             sendErrorResponse(response, SecurityErrorCode.INVALID_TOKEN);

--- a/src/main/java/inu/codin/codin/common/security/util/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/inu/codin/codin/common/security/util/OAuth2LoginSuccessHandler.java
@@ -61,7 +61,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
         switch (result) {
             case LOGIN_SUCCESS -> {
-                getRedirectStrategy().sendRedirect(request, response, redirectUrl + "/main");
+                getRedirectStrategy().sendRedirect(request, response, redirectUrl);
                 log.info("{\"code\":200, \"message\":\"정상 로그인 완료: {}\"}", email);
             }
             case NEW_USER_REGISTERED -> {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#259 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

#259 이슈에서 발생한 문제를 해결하기 위한 PR 입니다.

- 로그인 성공 후 리디렉트가 기본 리디렉트 URL로 이동하도록 수정해 의도치 않은 /main 경로 이동 문제를 해소했습니다.
-  토큰 검증 실패 시 401(Unauthorized) 응답을 일관되게 반환하도록 예외 처리를 처리 경고 로그 기록을 유지했습니다.
