### PR TITLE
feat : 투표 이벤트 관련 API 비로그인 유저 접근 허용

### DIFF
--- a/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
+++ b/src/main/java/inu/codin/codin/common/security/util/SecurityUtils.java
@@ -4,13 +4,16 @@ import inu.codin.codin.common.security.exception.JwtException;
 import inu.codin.codin.common.security.exception.SecurityErrorCode;
 import inu.codin.codin.domain.user.entity.UserRole;
 import inu.codin.codin.domain.user.security.CustomUserDetails;
+import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * SecurityContext와 관련된 유틸리티 클래스.
  */
+@Slf4j
 public class SecurityUtils {
 
     /**
@@ -20,10 +23,28 @@ public class SecurityUtils {
      * @throws JwtException 인증 정보가 없는 경우 예외 발생
      */
     public static ObjectId getCurrentUserId() {
+        log.info("getCurrentUserId.");
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
+        log.info("auth={} / principalClass={}", authentication, (authentication!=null ? authentication.getPrincipal().getClass() : null));
         if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
             throw new JwtException(SecurityErrorCode.ACCESS_DENIED);
+        }
+
+        return userDetails.getId();
+    }
+
+
+    /**
+     * 현재 인증된 사용자의 ID를 반환 (nullable 안전 버전)
+     * - 인증이 없거나 익명이면 null 반환
+     */
+    public static ObjectId getCurrentUserIdOrNull() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken
+                || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
+            return null;
         }
 
         return userDetails.getId();

--- a/src/main/java/inu/codin/codin/domain/block/service/BlockService.java
+++ b/src/main/java/inu/codin/codin/domain/block/service/BlockService.java
@@ -78,9 +78,15 @@ public class BlockService {
 
     /**
      * 현재 유저의 차단된 유저 목록 반환
+     * 인증이 없거나 익명이면 빈 리스트 반환
      * @return 차단한 유저 목록 (빈 리스트가 제공될 수 있음)
      */
     public List<ObjectId> getBlockedUsers() {
+        ObjectId currentUserId = SecurityUtils.getCurrentUserIdOrNull();
+        if (currentUserId == null) {
+            return List.of();
+        }
+
         return blockRepository.findByUserId(SecurityUtils.getCurrentUserId())
                 .map(BlockEntity::getBlockedUsers)
                 .orElse(List.of());

--- a/src/main/java/inu/codin/codin/domain/post/domain/hits/service/HitsService.java
+++ b/src/main/java/inu/codin/codin/domain/post/domain/hits/service/HitsService.java
@@ -44,9 +44,10 @@ public class HitsService {
      * 게시글 조회 여부 판단
      * @param postId 게시글 _id
      * @param userId 유저 _id
-     * @return true : 게시글 조회 유 , false : 게시글 조회 무
+     * @return true : 게시글 조회 유 , false : 게시글 조회 무 / 인증X (비로그인)
      */
     public boolean validateHits(ObjectId postId, ObjectId userId) {
+        if (userId == null) return false;
         return hitsRepository.existsByPostIdAndUserId(postId, userId);
     }
 

--- a/src/main/java/inu/codin/codin/domain/post/service/PostInteractionService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostInteractionService.java
@@ -1,12 +1,7 @@
 package inu.codin.codin.domain.post.service;
-
-import inu.codin.codin.common.exception.NotFoundException;
-import inu.codin.codin.domain.like.entity.LikeType;
-import inu.codin.codin.domain.like.service.LikeService;
 import inu.codin.codin.domain.post.domain.hits.service.HitsService;
 import inu.codin.codin.domain.post.entity.PostEntity;
 import inu.codin.codin.domain.post.repository.PostRepository;
-import inu.codin.codin.domain.scrap.service.ScrapService;
 import inu.codin.codin.infra.s3.S3Service;
 import inu.codin.codin.infra.s3.exception.ImageRemoveException;
 import inu.codin.codin.domain.post.exception.PostException;

--- a/src/main/java/inu/codin/codin/domain/post/service/PostQueryService.java
+++ b/src/main/java/inu/codin/codin/domain/post/service/PostQueryService.java
@@ -54,7 +54,7 @@ public class PostQueryService
      */
     public PostPageItemResponseDTO getPostWithDetail(String postId) {
         PostEntity post = findPostById(ObjectIdUtil.toObjectId(postId));
-        ObjectId userId = SecurityUtils.getCurrentUserId();
+        ObjectId userId = SecurityUtils.getCurrentUserIdOrNull();
         postInteractionService.increaseHits(post, userId);
         return postDtoAssembler.toPageItem(post, userId);
     }


### PR DESCRIPTION
# feat : 투표 이벤트 관련 API 비로그인 유저 접근 허용      

## 주요 변경사항
### Security , jwt.yml
- 비로그인 접근 허용 API 추가
   - 투표 이벤트 공개 API
      - "/posts/category"
      - "/posts/{postId}"
- SecurityUtils
   - getCurrentUserIdOrNull() 
   - 인증 정보가 없는 경우 null 반환 

### permitAll 경로에서도 토큰이 있으면 인증 세팅
- doFilterInternal 내에서 토큰 존재 시 permitAll 여부와 무관하게 인증 컨텍스트 세팅
- 토큰 미존재 시에만 permitAll 통과

### 조회수(Hits)
- 비로그인 유저 조회 시 조회수 증가 비활성화 
   - HitsEntity의 userId 필드가 @NotNull로 지정되어 있어 저장 불가
   - 추후 스키마 수정 후 로직 변경 예정 (논의 필요)

### 차단(Blocking)
- 인증되지 않은 사용자 요청 시 빈 리스트 반환하도록 변경
