### PR TITLE
fix : logout 시 AT 쿠키 삭제

### DIFF
--- a/src/main/java/inu/codin/codin/common/security/service/JwtService.java
+++ b/src/main/java/inu/codin/codin/common/security/service/JwtService.java
@@ -142,8 +142,10 @@ public class JwtService {
         log.info("[createBothToken] Access Token, Refresh Token 발급 완료, email = {}, Access: {}", authentication.getName(), newToken.getAccessToken());
     }
 
+
     /**
-     * 로그아웃 - Refresh Token 삭제
+     * 로그아웃 -
+     * Access,Refresh Token 제거/ 서버측 RT 삭제
      */
     public void deleteToken(HttpServletResponse response) {
         // 어차피 JwtAuthenticationFilter 단에서 토큰을 검증하여 인증을 처리하므로
@@ -163,6 +165,15 @@ public class JwtService {
         refreshCookie.setPath("/");
         refreshCookie.setMaxAge(0); // 7일
         response.addCookie(refreshCookie);
+        log.info("[deleteToken] Refresh Cookie 삭제 완료");
+
+        Cookie AccessCookie = new Cookie("x-access-token", "");
+        AccessCookie.setHttpOnly(true);
+        AccessCookie.setSecure(true);
+        AccessCookie.setPath("/");
+        AccessCookie.setMaxAge(0);
+        response.addCookie(AccessCookie);
+        log.info("[deleteToken] Access Cookie 삭제 완료");
     }
 
     public void setAuthentication(HttpServletRequest request){


### PR DESCRIPTION

## 📝 작업 내용

### fix : logout 시 AT 쿠키 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 로그아웃 시 리프레시 토큰뿐 아니라 액세스 토큰 쿠키도 함께 삭제되도록 수정. 서버 측 토큰 무효화와 쿠키 정리가 동시에 이뤄져, 일부 환경에서 로그아웃 후 계정이 즉시 다시 인증되거나 세션이 남는 문제를 해소. 공용/공유 기기에서 보안을 강화하고, 로그아웃 직후 재로그인이 일관되게 요구되어 사용자 혼란을 줄입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->