### PR TITLE
fix: post 단건/목록 JSON을 현재 프론트 요구사항에 맞게 정규화

### DIFF
--- a/src/main/java/inu/codin/codin/domain/post/dto/response/PostPageItemResponseDTO.java
+++ b/src/main/java/inu/codin/codin/domain/post/dto/response/PostPageItemResponseDTO.java
@@ -1,10 +1,14 @@
 package inu.codin.codin.domain.post.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostPageItemResponseDTO {
+    @JsonUnwrapped // 추후 프론트에 얘기해서 {post:{}, poll:{} 구조로 변경} 현재:{,,,poll:{}}
     private final PostDetailResponseDTO post;
     private final PollInfoResponseDTO poll;
 


### PR DESCRIPTION
- 추후 변경예정

## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용
### JSON Body
	- 단건 조회 응답에서 래퍼 키 제거
	- data: { post: {...}, poll: ... } → data: { ...postFields, poll? }
	- PostPageItemResponseDTO.post에 @JsonUnwrapped 적용
	- poll이 null일 때 필드 자체 미노출
	- DTO에 @JsonInclude(JsonInclude.Include.NON_NULL) 적용

## 요구 JSON 형식 ( 프론트와 협업후 다시 변경예정)
// Before
`{ "success": true, "data": { "post": { "_id": "...", "title": "..." }, "poll": null } }`

// After
`{ "success": true, "data": { "_id": "...", "title": "...", "poll": { ... } } }`
// poll == null 인 경우: "poll" 필드 자체 미노출

